### PR TITLE
fix(KeepAliveRoute): preserve children getter to avoid creating sibling routes

### DIFF
--- a/src/primitives/KeepAlive.tsx
+++ b/src/primitives/KeepAlive.tsx
@@ -156,6 +156,23 @@ const KeepAliveRouteInternal = createKeepAliveComponent(
   storeKeepAliveRoute,
 );
 
+// Cache the resolved <Route> JSX per key. Solid Router uses the routeDef
+// object itself as the route key (see @solidjs/router index.js:455), so if
+// KeepAliveRoute ever gets re-evaluated, a new routeDef would drift the key
+// and force routeStates to dispose + recreate sibling contexts (which would
+// re-invoke their components). Returning the same JSX reference keeps the
+// route key stable across re-evaluations.
+//
+// Note: this captures `props` at first invocation. If you rely on dynamic
+// changes to KeepAliveRoute props (e.g., a reactive `transition` or `preload`
+// reference), use a stable wrapper around them or clear this cache when
+// they change.
+const keepAliveRouteCache = new Map<string, s.JSX.Element>();
+
+export const clearKeepAliveRouteCache = (): void => {
+  keepAliveRouteCache.clear();
+};
+
 export const KeepAliveRoute = <S extends string>(
   props: RouteProps<S> & {
     id?: string;
@@ -173,6 +190,12 @@ export const KeepAliveRoute = <S extends string>(
   },
 ) => {
   const key = props.id || props.path;
+
+  const cached = keepAliveRouteCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
   let savedFocusedElement: ElementNode | undefined;
 
   const getExisting = () => {
@@ -246,23 +269,37 @@ export const KeepAliveRoute = <S extends string>(
       }
     : undefined;
 
-  return (
+  const componentWrapper = (childProps: RouteProps<S>) => {
+    const existing = getExisting();
+    // Do NOT spread `childProps`: it has a `children` getter (the router's
+    // outlet) that would be invoked eagerly, creating a <Show> subscribed to
+    // the next routeStates index. That stale Show would then fire when the
+    // user navigates to a sibling route whose matches populate that index,
+    // causing the sibling's component to be created from the preserved
+    // KeepAlive subtree. Inherit via prototype so the getter is preserved.
+    const innerProps = Object.create(childProps, {
+      isAlive: { value: existing.isAlive!, enumerable: true, configurable: true },
+    }) as RouteProps<S> & { isAlive: s.Accessor<boolean> };
+    return (
+      <KeepAliveRouteInternal
+        id={key}
+        onRemove={onRemove}
+        onRender={onRender}
+        transition={props.transition}
+      >
+        {props.component(innerProps)}
+      </KeepAliveRouteInternal>
+    );
+  };
+
+  const routeElement = (
     <Route
       {...props}
       preload={preload}
-      component={(childProps) => {
-        const existing = getExisting();
-        return (
-          <KeepAliveRouteInternal
-            id={key}
-            onRemove={onRemove}
-            onRender={onRender}
-            transition={props.transition}
-          >
-            {props.component({ ...childProps, isAlive: existing.isAlive! })}
-          </KeepAliveRouteInternal>
-        );
-      }}
+      component={componentWrapper}
     />
   );
+
+  keepAliveRouteCache.set(key, routeElement);
+  return routeElement;
 };


### PR DESCRIPTION
## Summary

Two related fixes inside `KeepAliveRoute`:

- **Stale Show subscribed to a sibling outlet.** The component wrapper used a spread to inject `isAlive` into the route props (`{ ...childProps, isAlive }`). That spread invokes the router's `get children()` getter, which builds a `<Show when={routeStates()[i+1]} keyed>` and subscribes it to `routeStates`. Because KeepAlive preserves the subtree across navigations, this Show stays alive after the user navigates away. When a later navigation populates `routeStates()[i+1]` with an unrelated sibling route's context, the stale Show fires and constructs the sibling's component out of the preserved subtree.

  **Concrete repro:** start at `/browse/:filter` (a `KeepAliveRoute`), then navigate to `/examples/tmdb`. `TMDB` is invoked twice — once from the stale Show in the preserved Browse subtree, once from the actual Portal render after the lazy import resolves.

  Fix: build the inner props via `Object.create(childProps, …)` instead of spreading. The `children` getter stays on the prototype chain and is only invoked when the user component actually reads it. No `Proxy`, so older platforms (Tizen/WebOS) keep working.

- **Route key drift on re-evaluation.** `<Route>` returns a fresh routeDef on every call, and solid-router uses that object identity as the route key (see `@solidjs/router` `createRoutes`). If `KeepAliveRoute` is re-evaluated, the new routeDef changes the key, which forces `routeStates` to dispose + recreate sibling contexts and re-invoke their components. Cache the resolved `<Route>` JSX per key so the routeDef identity is stable. The cache captures `props` at first invocation, so a `clearKeepAliveRouteCache()` escape hatch is exported for callers that need to refresh.

## Test plan

- [x] Verified the repro in the demo app: starting at `/browse/all` then navigating to `/examples/tmdb` constructs `TMDB` exactly once after the fix (previously twice).
- [ ] Confirm no regression in the normal mount/unmount/back-navigation cycle for `KeepAliveRoute` (focus restore, `isAlive` signal, `shouldDispose`, `preload`).
- [ ] Manual test: re-entering the keep-alive route preserves state.
- [ ] Manual test: forward navigation between two different `KeepAliveRoute`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)