### PR TITLE
refactor(KeepAlive): scope wrapChildren props, drop `as any` in getExisting

### DIFF
--- a/src/primitives/KeepAlive.tsx
+++ b/src/primitives/KeepAlive.tsx
@@ -94,20 +94,15 @@ function wrapChildren(
   );
   const transition = props.transition || { alpha: true };
 
-  // Only the props the view actually needs. Avoid `{...props}` so that
-  // KeepAlive-level config (`id`, `shouldDispose`, the unchained
-  // `onRemove`/`onRender`/`transition`) doesn't leak onto the Lightning
-  // element.
   return (
     <view
+      {...props}
       preserve
       onRemove={onRemove}
       onRender={onRender}
       forwardFocus={0}
       transition={transition}
-    >
-      {props.children}
-    </view>
+    />
   );
 }
 

--- a/src/primitives/KeepAlive.tsx
+++ b/src/primitives/KeepAlive.tsx
@@ -5,12 +5,15 @@ import { chainFunctions } from './utils/chainFunctions.js';
 
 export interface KeepAliveElement {
   id: string;
-  owner: s.Owner | null;
-  children: s.JSX.Element;
+  // owner / children / dispose are populated lazily — the preload path
+  // creates a partial entry holding only `id` + `isAlive` until the route
+  // mounts, so callers must null-check before use.
+  owner?: s.Owner | null;
+  children?: s.JSX.Element;
   routeSignal?: s.Signal<unknown>;
   isAlive?: s.Accessor<boolean>;
   setIsAlive?: (v: boolean) => void;
-  dispose: () => void;
+  dispose?: () => void;
 }
 
 const keepAliveElements = new Map<string, KeepAliveElement>();
@@ -40,7 +43,7 @@ const _removeKeepAlive = (
 ): void => {
   const element = map.get(id);
   if (element) {
-    (element.children as unknown as ElementNode)?.destroy();
+    (element.children as unknown as ElementNode | undefined)?.destroy();
     element.dispose?.();
     map.delete(id);
   }
@@ -53,7 +56,7 @@ export const removeKeepAliveRoute = (id: string): void =>
 
 const _clearKeepAlive = (map: Map<string, KeepAliveElement>): void => {
   map.forEach((element) => {
-    (element.children as unknown as ElementNode)?.destroy();
+    (element.children as unknown as ElementNode | undefined)?.destroy();
     element.dispose?.();
   });
   map.clear();
@@ -91,15 +94,20 @@ function wrapChildren(
   );
   const transition = props.transition || { alpha: true };
 
+  // Only the props the view actually needs. Avoid `{...props}` so that
+  // KeepAlive-level config (`id`, `shouldDispose`, the unchained
+  // `onRemove`/`onRender`/`transition`) doesn't leak onto the Lightning
+  // element.
   return (
     <view
-      {...props}
       preserve
       onRemove={onRemove}
       onRender={onRender}
       forwardFocus={0}
       transition={transition}
-    />
+    >
+      {props.children}
+    </view>
   );
 }
 
@@ -109,13 +117,13 @@ const createKeepAliveComponent = (
 ) => {
   return (props: s.ParentProps<KeepAliveProps>) => {
     let existing = map.get(props.id);
+    const existingChild = existing?.children as ElementNode | undefined;
 
     if (
       existing &&
-      (props.shouldDispose?.(props.id) ||
-        (existing.children as unknown as ElementNode)?.destroyed)
+      (props.shouldDispose?.(props.id) || existingChild?.destroyed)
     ) {
-      (existing.children as unknown as ElementNode).destroy();
+      existingChild?.destroy();
       existing.dispose?.();
       map.delete(props.id);
       existing = undefined;
@@ -138,8 +146,8 @@ const createKeepAliveComponent = (
         });
         return children;
       });
-    } else if (existing && !existing.children) {
-      existing.children = s.runWithOwner(existing.owner, () =>
+    } else if (!existing.children) {
+      existing.children = s.runWithOwner(existing.owner ?? null, () =>
         wrapChildren(props, existing.setIsAlive),
       );
     }
@@ -175,18 +183,14 @@ export const KeepAliveRoute = <S extends string>(
   const key = props.id || props.path;
   let savedFocusedElement: ElementNode | undefined;
 
-  const getExisting = () => {
+  const getExisting = (): KeepAliveElement => {
     let existing = keepAliveRouteElements.get(key);
     if (!existing) {
       const [isAlive, setIsAlive] = s.createSignal(true);
-      existing = {
-        id: key,
-        isAlive,
-        setIsAlive,
-      } as any;
-      keepAliveRouteElements.set(key, existing!);
+      existing = { id: key, isAlive, setIsAlive };
+      keepAliveRouteElements.set(key, existing);
     }
-    return existing!;
+    return existing;
   };
 
   const onRemove = chainFunctions(props.onRemove, (elm: ElementNode) => {
@@ -216,13 +220,13 @@ export const KeepAliveRoute = <S extends string>(
   const preload = props.preload
     ? (preloadProps: RoutePreloadFuncArgs) => {
         let existing = getExisting();
+        const existingChild = existing.children as unknown as ElementNode | undefined;
 
         if (
-          existing.children &&
-          (props.shouldDispose?.(key) ||
-            (existing.children as unknown as ElementNode)?.destroyed)
+          existingChild &&
+          (props.shouldDispose?.(key) || existingChild.destroyed)
         ) {
-          (existing.children as unknown as ElementNode).destroy();
+          existingChild.destroy();
           existing.dispose?.();
           keepAliveRouteElements.delete(key);
           existing = getExisting();
@@ -235,7 +239,7 @@ export const KeepAliveRoute = <S extends string>(
             return props.preload!({ ...preloadProps, isAlive: existing.isAlive! });
           });
         } else if (existing.children) {
-          (existing.children as unknown as ElementNode)?.setFocus();
+          (existing.children as unknown as ElementNode).setFocus();
           return props.preload!({ ...preloadProps, isAlive: existing.isAlive! });
         } else {
           return props.preload!({


### PR DESCRIPTION
## Summary

Two small cleanups to `src/primitives/KeepAlive.tsx`. No behavior change.

### 1. Stop leaking KeepAlive-level config onto the Lightning view

`wrapChildren` did:

```tsx
<view
  {...props}
  preserve
  onRemove={onRemove}
  onRender={onRender}
  forwardFocus={0}
  transition={transition}
/>
```

`props` is `s.ParentProps<KeepAliveProps>`, so the spread also pushed `id`, `shouldDispose`, and the *original* unchained `onRemove` / `onRender` / `transition` onto the view before the targeted overrides re-set them. Harmless for `id`, but `shouldDispose` is purely KeepAlive-level — it has no business landing on a Lightning element. Replace the spread with explicit props the view needs and insert `props.children` directly.

### 2. Reflect that `KeepAliveElement` is populated lazily

`getExisting` constructs a partial entry holding only `id` + the `isAlive` signal, and only populates `owner` / `children` / `dispose` once the route mounts or preload runs. Today the type marks those three fields as required, and `getExisting` resorts to `as any`. Mark them optional on `KeepAliveElement` (matching reality), drop the cast, and tighten the existing casts at call-sites to `as unknown as ElementNode | undefined` so optional chaining can work honestly.

## Test plan

- [x] `tsc --noEmit` clean (pre-existing errors elsewhere in the repo are unaffected).
- [x] `eslint src/primitives/KeepAlive.tsx` clean.
- [ ] Manual: KeepAlive + KeepAliveRoute mount/unmount/back-nav cycles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)