### PR TITLE
fix(navigation): preserve user transitions across directional navigation

### DIFF
--- a/src/primitives/Column.tsx
+++ b/src/primitives/Column.tsx
@@ -34,7 +34,6 @@ export const Column: Component<ColumnProps> = (props) => {
     <view
       transitionUp={defaultTransitionUp}
       transitionDown={defaultTransitionDown}
-      transition={/* @once */ {}}
       {...props}
       onUp={/* @once */ chainFunctions(props.onUp, onUp)}
       onDown={/* @once */ chainFunctions(props.onDown, onDown)}

--- a/src/primitives/Row.tsx
+++ b/src/primitives/Row.tsx
@@ -33,7 +33,6 @@ export const Row: Component<RowProps> = (props) => {
     <view
       transitionLeft={defaultTransitionBack}
       transitionRight={defaultTransitionForward}
-      transition={/* @once */ {}}
       {...props}
       selected={props.selected || 0}
       onLeft={/* @once */ chainFunctions(props.onLeft, onLeft)}

--- a/src/primitives/Virtual.tsx
+++ b/src/primitives/Virtual.tsx
@@ -540,7 +540,6 @@ function createVirtual<T>(
 
   return (
     <view
-      transition={/* @once */ {}}
       transitionLeft={isRow ? defaultTransitionBack : undefined}
       transitionRight={isRow ? defaultTransitionForward : undefined}
       transitionUp={!isRow ? defaultTransitionUp : undefined}

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -117,32 +117,41 @@ export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
   return selectChild(navigable, selected);
 };
 
+type NavWithTransitionCache = lngp.NavigableElement & {
+  _navBaseTransition?: object;
+  _navLastMerged?: object;
+};
+
 export function handleNavigation(
   direction: 'up' | 'right' | 'down' | 'left',
 ): lng.KeyHandler {
   return function () {
-    const el = this as lngp.NavigableElement;
-    const transition =
+    const el = this as NavWithTransitionCache;
+    const directional =
       direction === 'up'
         ? el.transitionUp
         : direction === 'down'
           ? el.transitionDown
           : direction === 'left'
             ? el.transitionLeft
-            : direction === 'right'
-              ? el.transitionRight
-              : undefined;
+            : el.transitionRight;
 
-    if (transition) {
-      const currentTransition =
+    if (directional) {
+      const current =
         typeof el.transition === 'object' && el.transition !== null
           ? el.transition
           : {};
 
-      el.transition = {
-        ...currentTransition,
-        ...(transition as object),
-      };
+      // Re-snapshot the developer-supplied transition whenever el.transition
+      // doesn't match our last merge — that means it was set externally
+      // (initial render or a reactive update), not by this handler.
+      if (current !== el._navLastMerged) {
+        el._navBaseTransition = current;
+      }
+
+      const merged = { ...(directional as object), ...el._navBaseTransition };
+      el.transition = merged;
+      el._navLastMerged = merged;
     }
 
     return moveSelection(


### PR DESCRIPTION
## Summary
- `handleNavigation` now snapshots the developer-supplied `transition` and merges as `{ ...directional, ...base }` so user-supplied keys (e.g. a custom `transition.x` duration) survive every keypress instead of being clobbered by `defaultTransitionBack`/`Forward`/`Up`/`Down`. The snapshot is re-taken whenever `el.transition` is set externally, so reactive updates still flow through.
- Drop the empty `transition={/* @once */ {}}` default from `Row`, `Column`, and `Virtual`. That default made `this.transition` non-undefined before `elementNode`'s style setter ran, which caused the setter to skip `style.transition` entirely ([elementNode.ts:1141-1145](https://github.com/solid-tv/solid/blob/main/src/core/elementNode.ts#L1141-L1145)). `handleNavigation` already tolerates an undefined `el.transition`, so the default isn't load-bearing.

Fixes #8

## Test plan
- [x] `npm run tsc` — clean
- [x] `npm test` — 120/120 passing
- [ ] Verify in a sample app: setting `transition={{ x: { duration: 500 } }}` on a `Row` keeps that duration after pressing left/right
- [ ] Verify `style={{ transition: { x: {...} } }}` on a `Row` is now honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)