### PR TITLE
feat(virtual): derive visibleCount and overscan from container size

### DIFF
--- a/docs/primitives/virtual.md
+++ b/docs/primitives/virtual.md
@@ -5,8 +5,9 @@
 ### Behavior
 
 - Renders a 1D list of items.
-- Uses `displaySize` to define the number of visible items.
-- Uses `bufferSize` to pre-render additional items to the left and right of the visible window for smoother scrolling.
+- Visible count and overscan buffer are derived automatically from the container size and the first child's measured size — no need to pass `displaySize` or `bufferSize`.
+- On mount, a single probe item is rendered so the layout pass can measure it; the full slice is rendered as soon as measurement completes.
+- Item size is assumed uniform; the first child is the reference. If your dataset swaps to differently-sized items, remount the component.
 - Only a subset of the total items is rendered, improving performance.
 - Triggers `onEndReached` when the user approaches the end of the list, allowing for infinite scrolling or fetching more data.
 - Focus is updated and maintained internally, with optional control via `scrollToIndex`.
@@ -20,8 +21,7 @@ import { VirtualRow, VirtualColumn } from './primitives/Virtual';
 <VirtualRow
   x={100}
   y={100}
-  displaySize={5}
-  bufferSize={2}
+  width={1720}
   each={myItemsArray}
   onEndReached={loadMoreItems}
   onEndReachedThreshold={3}
@@ -32,18 +32,16 @@ import { VirtualRow, VirtualColumn } from './primitives/Virtual';
 </VirtualRow>;
 ```
 
+The container must have a measurable `width` (for `VirtualRow`) or `height` (for `VirtualColumn`) on first layout — either set explicitly or sized by a flex parent that has finished laying out.
+
 ### Props
 
 - **each** (`readonly T[] | undefined | null | false`): The full list of items to be rendered.
-- **displaySize** (`number`): Number of items per row (required).
-- **bufferSize** (`number`): Number of items to pre-render above and below the visible area (default: `2`).
 - **wrap** (`boolean`): If `true`, navigation wraps around the ends of the list and scrolling loops infinitely.
 - **scrollIndex** (`number`): Specifies the index within the visible window where the focus should be anchored during scrolling.
-- **onEndReached** (`() => void`): Callback triggered when selection moves near the end of the list Requires `onEndReachedThreshold` to be set.
+- **onEndReached** (`() => void`): Callback triggered when selection moves near the end of the list. Requires `onEndReachedThreshold` to be set.
 - **onEndReachedThreshold** (`number`): Number from end of items when `onEndReached` will be called (default: `undefined`).
-- **debugInfo** (`boolean`): Logs internal slice recalculations and bounds shifts to console.
-- **factorScale** (`boolean`): If `true`, scrolling calculations will take item focus scale into account.
-- **uniformSize** (`boolean`): If `true` (default), assumes all items are uniform size to calculate scrolling, improving performance.
+- **debugInfo** (`boolean`): Logs internal slice recalculations, derived dimensions, and bounds shifts to the console.
 - **children** (`(item: Accessor<T>, index: Accessor<number>) => JSX.Element`): Function that renders each item.
 - **selected** (`number`): Initial selected index.
 - **autofocus** (`boolean`): If `true`, the component will auto-focus the first item on mount.
@@ -54,15 +52,29 @@ Use `cursor` property on the node to get the absolute index in the list of items
 ### Performance Optimization
 
 - Renders only a subset of the full list (`slice`) for improved memory and render-time performance.
+- Visible count and buffer are computed once from a single child measurement, then cached.
 - Automatically re-calculates the slice on selection or data change.
 - Reuses Children components
 - Merges styles with internal layout defaults:
-  - `display: flex`, `flexWrap: wrap`, `gap: 30`
-  - `transition: { y: 250ms ease-out }`
+  - `display: flex`, `gap: 30`
+  - Column variant adds `flexDirection: column`
 
 ### Focus & Navigation
 
 - Focus is managed via `selected` and handled automatically when navigating.
-- Navigation jumps vertically by row (`onUp`, `onDown`) and horizontally by item (`onLeft`, `onRight`).
-- When the selected index crosses a row boundary, the slice is updated and the grid scrolls accordingly.
+- Navigation moves by item (`onLeft`/`onRight` for `VirtualRow`, `onUp`/`onDown` for `VirtualColumn`).
+- When selection crosses the window edge, the slice is updated and the row/column scrolls accordingly.
 - Internal `onSelectedChanged` adjusts for slice-relative index offset to maintain correct selection.
+
+### Migration from previous versions
+
+The following props were removed and are now derived automatically:
+
+| Removed prop  | Replacement                                      |
+| ------------- | ------------------------------------------------ |
+| `displaySize` | derived from `container size / first child size` |
+| `bufferSize`  | derived as `max(2, ceil(visibleCount * 0.25))`   |
+| `uniformSize` | always treated as uniform (was the default)      |
+| `factorScale` | dropped; layout uses unscaled item size          |
+
+If you previously passed `displaySize` to constrain how many items render, set `width`/`height` on the container instead — the visible count will follow.

--- a/src/primitives/Virtual.tsx
+++ b/src/primitives/Virtual.tsx
@@ -12,16 +12,18 @@ import {
 
 export type VirtualProps<T> = lng.NewOmit<lngp.RowProps, 'children'> & {
   each: readonly T[] | undefined | null | false;
-  displaySize: number;
-  bufferSize?: number;
   wrap?: boolean;
   scrollIndex?: number;
   onEndReached?: () => void;
   onEndReachedThreshold?: number;
   debugInfo?: boolean;
-  factorScale?: boolean;
-  uniformSize?: boolean;
   children: (item: s.Accessor<T>, index: s.Accessor<number>) => s.JSX.Element;
+};
+
+type DerivedDims = {
+  visibleCount: number;
+  bufferSize: number;
+  itemSize: number;
 };
 
 function createVirtual<T>(
@@ -31,29 +33,36 @@ function createVirtual<T>(
 ) {
   const isRow = component === lngp.Row;
   const axis = isRow ? 'x' : 'y';
+  const sizeDim = isRow ? 'width' : 'height';
   const [cursor, setCursor] = s.createSignal(props.selected ?? 0);
-  const bufferSize = s.createMemo(() => props.bufferSize || 2);
   const scrollIndex = s.createMemo(() => props.scrollIndex || 0);
   const items = s.createMemo(() => props.each || []);
   const itemCount = s.createMemo(() => items().length);
   const scrollType = s.createMemo(() => props.scroll || 'auto');
 
+  // Derived from a single measurement of the container + first child.
+  // `undefined` means we haven't measured yet — slice rendering stays in probe mode.
+  const [derivedDims, setDerivedDims] = s.createSignal<DerivedDims | undefined>();
+  const visibleCount = () => derivedDims()?.visibleCount ?? 0;
+  const bufferSize = () => derivedDims()?.bufferSize ?? 2;
+
   const selected = () => {
-    if (itemCount() <= props.displaySize) {
-      return utils.clamp(props.selected || 0, 0, Math.max(0, itemCount() - 1));
+    const vc = visibleCount();
+    const total = itemCount();
+    if (!vc) {
+      return utils.clamp(props.selected || 0, 0, Math.max(0, total - 1));
+    }
+    if (total <= vc) {
+      return utils.clamp(props.selected || 0, 0, Math.max(0, total - 1));
     }
     if (props.wrap) {
       return Math.max(bufferSize(), scrollIndex());
     }
-    return utils.clamp(props.selected || 0, 0, Math.max(0, itemCount() - 1));
+    return utils.clamp(props.selected || 0, 0, Math.max(0, total - 1));
   };
 
-  let cachedScaledSize: number | undefined;
   let targetPosition: number | undefined;
   let cachedAnimationController: lng.IAnimationController | undefined;
-  const uniformSize = s.createMemo(() => {
-    return props.uniformSize !== false;
-  });
 
   type SliceState = {
     start: number;
@@ -82,24 +91,8 @@ function createVirtual<T>(
     return delta;
   }
 
-  function computeSize(selected: number = 0) {
-    if (uniformSize() && cachedScaledSize) {
-      return cachedScaledSize;
-    } else if (viewRef) {
-      const gap = viewRef.gap || 0;
-      const dimension = isRow ? 'width' : 'height'; // This can't be moved up as it depends on viewRef
-      const prevSelectedChild = viewRef.children[selected];
-
-      if (prevSelectedChild instanceof lng.ElementNode) {
-        const itemSize = prevSelectedChild[dimension] || 0;
-        const focusStyle = prevSelectedChild.style?.focus as lng.NodeStyles;
-        const scale = focusStyle?.scale ?? prevSelectedChild.scale ?? 1;
-        const scaledSize = itemSize * (props.factorScale ? scale : 1) + gap;
-        cachedScaledSize = scaledSize;
-        return scaledSize;
-      }
-    }
-    return 0;
+  function computeSize() {
+    return derivedDims()?.itemSize ?? 0;
   }
 
   function computeSlice(
@@ -108,7 +101,8 @@ function createVirtual<T>(
     prev: SliceState,
   ): SliceState {
     const total = itemCount();
-    if (total === 0)
+    const vc = visibleCount();
+    if (total === 0 || vc === 0)
       return {
         start: 0,
         slice: [],
@@ -119,7 +113,7 @@ function createVirtual<T>(
         cursor: 0,
       };
 
-    if (total <= props.displaySize) {
+    if (total <= vc) {
       return {
         start: 0,
         slice: items() as T[],
@@ -131,7 +125,8 @@ function createVirtual<T>(
       };
     }
 
-    const length = props.displaySize + bufferSize();
+    const buf = bufferSize();
+    const length = vc + buf;
     let start = prev.start;
     let selected = prev.selected;
     let atStart = prev.atStart;
@@ -144,20 +139,20 @@ function createVirtual<T>(
           selected = 1;
         } else {
           start = utils.clamp(
-            c - bufferSize(),
+            c - buf,
             0,
-            Math.max(0, total - props.displaySize - bufferSize()),
+            Math.max(0, total - vc - buf),
           );
           if (delta === 0 && c > 3) {
             shiftBy = c < 3 ? -c : -2;
             selected = 2;
           } else {
             selected =
-              c < bufferSize()
+              c < buf
                 ? c
-                : c >= total - props.displaySize
-                  ? c - (total - props.displaySize) + bufferSize()
-                  : bufferSize();
+                : c >= total - vc
+                  ? c - (total - vc) + buf
+                  : buf;
           }
         }
         break;
@@ -173,21 +168,17 @@ function createVirtual<T>(
         } else {
           if (delta < 0) {
             // Moving left
-            if (prev.start > 0 && prev.selected >= props.displaySize) {
-              // Move selection left inside slice
+            if (prev.start > 0 && prev.selected >= vc) {
               start = prev.start;
               selected = prev.selected - 1;
             } else if (prev.start > 0) {
-              // Move selection left inside slice
               start = prev.start - 1;
               selected = prev.selected;
-              // shiftBy = 0;
             } else if (prev.start === 0 && !prev.atStart) {
               start = 0;
               selected = prev.selected - 1;
               atStart = true;
-            } else if (selected >= props.displaySize - 1) {
-              // Shift window left, keep selection pinned
+            } else if (selected >= vc - 1) {
               start = 0;
               selected = prev.selected - 1;
             } else {
@@ -198,7 +189,6 @@ function createVirtual<T>(
           } else if (delta > 0) {
             // Moving right
             if (prev.selected < scrollIndex()) {
-              // Move selection right inside slice
               start = prev.start;
               selected = prev.selected + 1;
               shiftBy = 0;
@@ -210,13 +200,11 @@ function createVirtual<T>(
               start = 0;
               selected = 1;
               atStart = false;
-            } else if (prev.start >= total - props.displaySize) {
-              // At end: clamp slice, selection drifts right
+            } else if (prev.start >= total - vc) {
               start = prev.start;
               selected = c - start;
               shiftBy = 0;
             } else {
-              // Shift window right, keep selection pinned
               start = prev.start + 1;
               selected = Math.max(prev.selected, scrollIndex() + 1);
             }
@@ -225,7 +213,7 @@ function createVirtual<T>(
             if (c > 0) {
               start = Math.min(
                 c - (scrollIndex() || 1),
-                total - props.displaySize - bufferSize(),
+                total - vc - buf,
               );
               selected = Math.max(scrollIndex() || 1, c - start);
               shiftBy = total - c < 3 ? c - total : -1;
@@ -250,7 +238,7 @@ function createVirtual<T>(
       case 'edge': {
         const startScrolling = Math.max(
           1,
-          props.displaySize + (atStart ? -1 : 0),
+          vc + (atStart ? -1 : 0),
         );
         if (props.wrap) {
           if (delta > 0) {
@@ -280,7 +268,6 @@ function createVirtual<T>(
           }
         } else {
           if (delta === 0 && c > 0) {
-            //initial setup
             selected = c > startScrolling ? startScrolling : c;
             start = Math.max(0, c - startScrolling + 1);
             shiftBy = c > startScrolling ? -1 : 0;
@@ -363,7 +350,7 @@ function createVirtual<T>(
 
   function scrollToIndex(this: lng.ElementNode, index: number) {
     s.untrack(() => {
-      if (itemCount() === 0) return;
+      if (itemCount() === 0 || !derivedDims()) return;
 
       lastNavTime = performance.now();
       if (originalPosition !== undefined) {
@@ -407,10 +394,11 @@ function createVirtual<T>(
       props.onSelectedChanged.call(this, idx, this, active, lastIdx);
     }
 
-    if (noChange) return;
+    if (noChange || !derivedDims()) return;
 
     const rawDelta = idx - (lastIdx ?? 0);
-    const windowLen = elm?.children?.length ?? props.displaySize + bufferSize();
+    const windowLen =
+      elm?.children?.length ?? visibleCount() + bufferSize();
     const delta = props.wrap
       ? normalizeDeltaForWindow(rawDelta, windowLen)
       : rawDelta;
@@ -439,7 +427,7 @@ function createVirtual<T>(
 
     queueMicrotask(() => {
       elm.updateLayout();
-      const childSize = computeSize(slice().selected);
+      const childSize = computeSize();
 
       if (
         cachedAnimationController &&
@@ -465,7 +453,8 @@ function createVirtual<T>(
   };
 
   const updateSelected = ([sel, _items]: [number?, any?]) => {
-    if (!viewRef || sel === undefined || itemCount() === 0) return;
+    if (!viewRef || sel === undefined || itemCount() === 0 || !derivedDims())
+      return;
     const safeSel = utils.clamp(sel, 0, itemCount() - 1);
     const item = items()[safeSel];
     setCursor(safeSel);
@@ -483,7 +472,7 @@ function createVirtual<T>(
 
       if (newState.shiftBy === 0) return;
 
-      const childSize = computeSize(slice().selected);
+      const childSize = computeSize();
       // Original Position is offset to support scrollToIndex
       originalPosition = originalPosition ?? viewRef.lng[axis];
       targetPosition = targetPosition ?? viewRef.lng[axis];
@@ -492,12 +481,64 @@ function createVirtual<T>(
     });
   };
 
+  // Measure container + first probe child, derive visibleCount/bufferSize.
+  function measureAndInit() {
+    if (!viewRef || derivedDims() || itemCount() === 0) return;
+
+    viewRef.updateLayout();
+    const containerSize = viewRef[sizeDim] || 0;
+    if (!containerSize) return;
+
+    const firstChild = viewRef.children[0];
+    if (!(firstChild instanceof lng.ElementNode)) return;
+
+    const childSize = firstChild[sizeDim] || 0;
+    if (!childSize) return;
+
+    const gap = viewRef.gap || 0;
+    const itemSize = childSize + gap;
+    const vc = Math.max(1, Math.floor(containerSize / itemSize));
+    const buf = Math.max(2, Math.ceil(vc * 0.25));
+
+    if (props.debugInfo) {
+      console.log('[Virtual] measured', {
+        containerSize,
+        childSize,
+        gap,
+        visibleCount: vc,
+        bufferSize: buf,
+      });
+    }
+
+    setDerivedDims({ visibleCount: vc, bufferSize: buf, itemSize });
+
+    const sel = utils.clamp(props.selected ?? 0, 0, itemCount() - 1);
+    setCursor(sel);
+    const initialState = computeSlice(sel, 0, slice());
+    setSlice(initialState);
+    viewRef.selected = initialState.selected;
+  }
+
+  // Re-attempt measurement when items first populate (covers async load).
+  s.createEffect(() => {
+    items();
+    if (!viewRef || derivedDims() || itemCount() === 0) return;
+    queueMicrotask(measureAndInit);
+  });
+
   let doOnce = false;
   s.createEffect(
     s.on([() => props.wrap, items], () => {
-      if (!viewRef || itemCount() === 0 || !props.wrap || doOnce) return;
+      if (
+        !viewRef ||
+        itemCount() === 0 ||
+        !props.wrap ||
+        doOnce ||
+        !derivedDims()
+      )
+        return;
       doOnce = true;
-      if (itemCount() <= props.displaySize) {
+      if (itemCount() <= visibleCount()) {
         queueMicrotask(() => {
           originalPosition = viewRef.lng[axis];
           targetPosition = viewRef.lng[axis];
@@ -506,7 +547,7 @@ function createVirtual<T>(
       }
       // offset just for wrap so we keep one item before
       queueMicrotask(() => {
-        const childSize = computeSize(slice().selected);
+        const childSize = computeSize();
         viewRef.lng[axis] = (viewRef.lng[axis] || 0) + childSize * -1;
         // Original Position is offset to support scrollToIndex
         originalPosition = viewRef.lng[axis];
@@ -519,7 +560,7 @@ function createVirtual<T>(
 
   s.createEffect(
     s.on(items, () => {
-      if (!viewRef) return;
+      if (!viewRef || !derivedDims()) return;
       let c = cursor();
       if (c >= itemCount()) {
         c = Math.max(0, itemCount() - 1);
@@ -531,6 +572,16 @@ function createVirtual<T>(
     }),
   );
 
+  // Before measurement completes, render just the first item so we have
+  // something to measure. Once derivedDims is set, render the real slice.
+  const renderedSlice = s.createMemo(() => {
+    if (!derivedDims()) {
+      const list = items();
+      return list.length > 0 ? ([list[0]] as T[]) : [];
+    }
+    return slice().slice;
+  });
+
   return (
     <view
       transitionLeft={isRow ? defaultTransitionBack : undefined}
@@ -541,6 +592,7 @@ function createVirtual<T>(
       {...keyHandlers}
       ref={lngp.chainRefs((el) => {
         viewRef = el as lngp.NavigableElement;
+        queueMicrotask(measureAndInit);
       }, props.ref)}
       selected={selected()}
       cursor={cursor()}
@@ -563,7 +615,7 @@ function createVirtual<T>(
         )
       }
     >
-      <List each={slice().slice}>{props.children}</List>
+      <List each={renderedSlice()}>{props.children}</List>
     </view>
   );
 }

--- a/src/primitives/Virtual.tsx
+++ b/src/primitives/Virtual.tsx
@@ -485,7 +485,7 @@ function createVirtual<T>(
   function measureAndInit() {
     if (!viewRef || derivedDims() || itemCount() === 0) return;
 
-    viewRef.updateLayout();
+    // viewRef.updateLayout();
     const containerSize = viewRef[sizeDim] || 0;
     if (!containerSize) return;
 
@@ -498,7 +498,7 @@ function createVirtual<T>(
     const gap = viewRef.gap || 0;
     const itemSize = childSize + gap;
     const vc = Math.max(1, Math.floor(containerSize / itemSize));
-    const buf = Math.max(2, Math.ceil(vc * 0.25));
+    const buf = Math.max(2, Math.ceil(vc * 0.3));
 
     if (props.debugInfo) {
       console.log('[Virtual] measured', {
@@ -599,6 +599,7 @@ function createVirtual<T>(
       forwardFocus={/* @once */ lngp.navigableForwardFocus}
       scrollToIndex={/* @once */ scrollToIndex}
       onSelectedChanged={/* @once */ onSelectedChanged}
+      flexBoundary='fixed'
       style={
         /* @once */ lng.combineStyles(
           props.style,

--- a/src/primitives/Virtual.tsx
+++ b/src/primitives/Virtual.tsx
@@ -100,8 +100,17 @@ function createVirtual<T>(
     delta: number,
     prev: SliceState,
   ): SliceState {
+    // Hoist every memo read used inside this function — they're constants for
+    // the duration of one slice computation, and pulling them up keeps the
+    // switch branches focused on the actual math.
     const total = itemCount();
     const vc = visibleCount();
+    const buf = bufferSize();
+    const si = scrollIndex();
+    const allItems = items();
+    const wrap = !!props.wrap;
+    const mode = scrollType();
+
     if (total === 0 || vc === 0)
       return {
         start: 0,
@@ -116,7 +125,7 @@ function createVirtual<T>(
     if (total <= vc) {
       return {
         start: 0,
-        slice: items() as T[],
+        slice: allItems as T[],
         selected: utils.clamp(c, 0, total - 1),
         delta,
         shiftBy: 0,
@@ -125,16 +134,15 @@ function createVirtual<T>(
       };
     }
 
-    const buf = bufferSize();
     const length = vc + buf;
     let start = prev.start;
     let selected = prev.selected;
     let atStart = prev.atStart;
     let shiftBy = -delta;
 
-    switch (scrollType()) {
+    switch (mode) {
       case 'always':
-        if (props.wrap) {
+        if (wrap) {
           start = utils.mod(c - 1, total);
           selected = 1;
         } else {
@@ -158,10 +166,10 @@ function createVirtual<T>(
         break;
 
       case 'auto':
-        if (props.wrap) {
+        if (wrap) {
           if (delta === 0) {
-            selected = scrollIndex() || 1;
-            start = utils.mod(c - (scrollIndex() || 1), total);
+            selected = si || 1;
+            start = utils.mod(c - (si || 1), total);
           } else {
             start = utils.mod(c - (prev.selected || 1), total);
           }
@@ -188,11 +196,11 @@ function createVirtual<T>(
             }
           } else if (delta > 0) {
             // Moving right
-            if (prev.selected < scrollIndex()) {
+            if (prev.selected < si) {
               start = prev.start;
               selected = prev.selected + 1;
               shiftBy = 0;
-            } else if (prev.selected === scrollIndex() || atStart) {
+            } else if (prev.selected === si || atStart) {
               start = prev.start;
               selected = prev.selected + 1;
               atStart = false;
@@ -206,16 +214,16 @@ function createVirtual<T>(
               shiftBy = 0;
             } else {
               start = prev.start + 1;
-              selected = Math.max(prev.selected, scrollIndex() + 1);
+              selected = Math.max(prev.selected, si + 1);
             }
           } else {
             // Initial setup
             if (c > 0) {
               start = Math.min(
-                c - (scrollIndex() || 1),
+                c - (si || 1),
                 total - vc - buf,
               );
-              selected = Math.max(scrollIndex() || 1, c - start);
+              selected = Math.max(si || 1, c - start);
               shiftBy = total - c < 3 ? c - total : -1;
               atStart = false;
             } else {
@@ -240,7 +248,7 @@ function createVirtual<T>(
           1,
           vc + (atStart ? -1 : 0),
         );
-        if (props.wrap) {
+        if (wrap) {
           if (delta > 0) {
             if (prev.selected < startScrolling) {
               selected = prev.selected + 1;
@@ -314,12 +322,12 @@ function createVirtual<T>(
 
     let newSlice = prev.slice;
     if (start !== prev.start || newSlice.length === 0) {
-      newSlice = props.wrap
+      newSlice = wrap
         ? (Array.from(
             { length },
-            (_, i) => items()[utils.mod(start + i, total)],
+            (_, i) => allItems[utils.mod(start + i, total)],
           ) as T[])
-        : items().slice(start, start + length);
+        : allItems.slice(start, start + length);
     }
 
     const state: SliceState = {
@@ -377,6 +385,10 @@ function createVirtual<T>(
   }
 
   let originalPosition: number | undefined;
+  // Tracks whether we've already fired onEndReached for the current "in-zone"
+  // state. Resets when the cursor moves back out of the threshold, so callers
+  // get exactly one call per crossing instead of one per keypress.
+  let endReachedFired = false;
   const onSelectedChanged: lngp.OnSelectedChanged = function (
     _idx,
     elm,
@@ -414,11 +426,15 @@ function createVirtual<T>(
     setSlice(newState);
     elm.selected = newState.selected;
 
-    if (
-      props.onEndReachedThreshold !== undefined &&
-      cursor() >= itemCount() - props.onEndReachedThreshold
-    ) {
-      props.onEndReached?.();
+    if (props.onEndReachedThreshold !== undefined) {
+      const crossed =
+        cursor() >= itemCount() - props.onEndReachedThreshold;
+      if (crossed && !endReachedFired) {
+        endReachedFired = true;
+        props.onEndReached?.();
+      } else if (!crossed && endReachedFired) {
+        endReachedFired = false;
+      }
     }
 
     if (newState.shiftBy === 0) return;
@@ -561,6 +577,8 @@ function createVirtual<T>(
   s.createEffect(
     s.on(items, () => {
       if (!viewRef || !derivedDims()) return;
+      // "End" moves when data changes; allow onEndReached to fire again.
+      endReachedFired = false;
       let c = cursor();
       if (c >= itemCount()) {
         c = Math.max(0, itemCount() - 1);

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -18,16 +18,20 @@ export * from './Suspense.jsx';
 export * from './Marquee.jsx';
 export * from './createFocusStack.jsx';
 export * from './useHold.js';
+// withScrolling/handleNavigation are re-exported BEFORE VirtualGrid/Virtual/Rail
+// because those modules evaluate `lngp.withScrolling(...)` (etc.) at module-load
+// time, and would otherwise see a partial namespace via the primitives barrel.
+export * from './utils/withScrolling.js';
+export * from './utils/handleNavigation.js';
 export * from './VirtualGrid.jsx';
 export * from './Virtual.jsx';
-export * from './utils/withScrolling.js';
+export * from './Rail.jsx';
 export * from './createTag.jsx';
 export {
   type AnyFunction,
   chainFunctions,
   chainRefs,
 } from './utils/chainFunctions.js';
-export * from './utils/handleNavigation.js';
 export { createSpriteMap, type SpriteDef } from './utils/createSpriteMap.js';
 export { createBlurredImage } from './utils/createBlurredImage.js';
 

--- a/tests/virtual.test.tsx
+++ b/tests/virtual.test.tsx
@@ -1,0 +1,443 @@
+import * as v from 'vitest';
+import * as s from 'solid-js';
+import * as lng from '@solidtv/solid';
+import { VirtualRow } from '../src/primitives/Virtual.jsx';
+import { moveSelection } from '../src/primitives/utils/handleNavigation.js';
+import type { NavigableElement } from '../src/primitives/types.js';
+
+import { renderer, waitForUpdate } from './setup.js';
+
+const ITEM_W = 300;
+const ITEM_H = 400;
+const GAP = 30; // Virtual hardcodes this in its style
+const STRIDE = ITEM_W + GAP;
+const CONTAINER_W = 1820;
+
+const Poster = (props: { item: number; index: number }) => (
+  <view width={ITEM_W} height={ITEM_H} color={0xff0000ff} />
+);
+
+/**
+ * Returns the underlying ElementNode that VirtualRow renders as its container.
+ * That container's children are the rendered slice items.
+ */
+function getRailContainer(ref: lng.ElementNode | undefined): lng.ElementNode {
+  if (!ref) throw new Error('ref not assigned');
+  return ref;
+}
+
+v.describe('VirtualRow', () => {
+  v.test('renders nothing when each is undefined', async () => {
+    let virtualRef!: lng.ElementNode;
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef}
+        each={undefined}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.children.length, 0);
+    dispose();
+  });
+
+  v.test('renders nothing when each is an empty array', async () => {
+    let virtualRef!: lng.ElementNode;
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef}
+        each={[]}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.children.length, 0);
+    dispose();
+  });
+
+  v.test('probe phase renders a single item until measurement completes', async () => {
+    let virtualRef!: lng.ElementNode;
+    const items = Array.from({ length: 30 }, (_, i) => i);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef}
+        each={items}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    // Before microtasks run, the probe-render path is active.
+    v.assert.isAtLeast(virtualRef.children.length, 1);
+
+    await waitForUpdate();
+
+    // After measurement, the slice expands to visibleCount + bufferSize.
+    // visibleCount = floor(1820 / 330) = 5
+    // bufferSize   = max(2, ceil(5 * 0.3)) = 2
+    // slice length = visibleCount + bufferSize = 7
+    v.assert.equal(virtualRef.children.length, 7);
+
+    dispose();
+  });
+
+  v.test('initial cursor reflects the `selected` prop', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 30 }, (_, i) => i);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={5}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.cursor, 5);
+    dispose();
+  });
+
+  v.test('updating `each` from undefined to populated expands the slice', async () => {
+    let virtualRef!: lng.ElementNode;
+    const [data, setData] = s.createSignal<number[] | undefined>(undefined);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef}
+        each={data()}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+    v.assert.equal(virtualRef.children.length, 0);
+
+    setData(Array.from({ length: 30 }, (_, i) => i));
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.children.length, 7);
+    dispose();
+  });
+
+  v.test('updating `each` to a longer array does not exceed the window', async () => {
+    let virtualRef!: lng.ElementNode;
+    const [data, setData] = s.createSignal<number[]>(
+      Array.from({ length: 30 }, (_, i) => i),
+    );
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef}
+        each={data()}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+    v.assert.equal(virtualRef.children.length, 7);
+
+    setData(Array.from({ length: 200 }, (_, i) => i));
+    await waitForUpdate();
+
+    // Still a windowed slice — not the full 200.
+    v.assert.equal(virtualRef.children.length, 7);
+    dispose();
+  });
+
+  v.test('updating `each` to fewer items than the window renders them all', async () => {
+    let virtualRef!: lng.ElementNode;
+    const [data, setData] = s.createSignal<number[]>(
+      Array.from({ length: 30 }, (_, i) => i),
+    );
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef}
+        each={data()}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+    v.assert.equal(virtualRef.children.length, 7);
+
+    setData([0, 1, 2]);
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.children.length, 3);
+    dispose();
+  });
+
+  v.test('onSelectedChanged fires when moveSelection advances the cursor', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 30 }, (_, i) => i);
+    const onSelectedChanged = v.vi.fn();
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={0}
+        width={CONTAINER_W}
+        height={ITEM_H}
+        onSelectedChanged={onSelectedChanged}
+        autofocus
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    onSelectedChanged.mockClear();
+
+    // Simulate a right arrow keypress by directly invoking the navigation helper.
+    moveSelection(virtualRef, 1);
+    await waitForUpdate();
+
+    v.assert.equal(onSelectedChanged.mock.calls.length >= 1, true);
+    v.assert.equal(virtualRef.cursor, 1);
+
+    dispose();
+  });
+
+  v.test('cursor advances repeatedly under successive moveSelection calls', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 30 }, (_, i) => i);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={0}
+        width={CONTAINER_W}
+        height={ITEM_H}
+        autofocus
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    for (let step = 0; step < 8; step++) {
+      moveSelection(virtualRef, 1);
+      await waitForUpdate();
+    }
+
+    v.assert.equal(virtualRef.cursor, 8);
+    // Slice should still be windowed, not the whole list.
+    v.assert.isAtMost(virtualRef.children.length, 7);
+    dispose();
+  });
+
+  v.test('onEndReached fires when cursor crosses the threshold', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+    const onEndReached = v.vi.fn();
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={0}
+        width={CONTAINER_W}
+        height={ITEM_H}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={2}
+        autofocus
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+    onEndReached.mockClear();
+
+    // total=10, threshold=2 → fires when cursor >= 8
+    for (let step = 0; step < 8; step++) {
+      moveSelection(virtualRef, 1);
+      await waitForUpdate();
+    }
+
+    // Latched: should have fired exactly once when the cursor first crossed
+    // the threshold, then stayed silent for the remaining in-zone keypresses.
+    v.assert.equal(onEndReached.mock.calls.length, 1);
+
+    // Moving back out of the zone and back in should re-arm and fire again.
+    onEndReached.mockClear();
+    moveSelection(virtualRef, -1);
+    await waitForUpdate();
+    moveSelection(virtualRef, 1);
+    await waitForUpdate();
+    v.assert.equal(onEndReached.mock.calls.length, 1);
+
+    dispose();
+  });
+
+  v.test('scrollToIndex jumps the cursor to the target', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 30 }, (_, i) => i);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={0}
+        width={CONTAINER_W}
+        height={ITEM_H}
+        autofocus
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    virtualRef.scrollToIndex(15);
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.cursor, 15);
+    dispose();
+  });
+
+  v.test('scrollToIndex clamps out-of-range targets', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={0}
+        width={CONTAINER_W}
+        height={ITEM_H}
+        autofocus
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    virtualRef.scrollToIndex(999);
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.cursor, 9);
+
+    virtualRef.scrollToIndex(-5);
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.cursor, 0);
+    dispose();
+  });
+
+  v.test('updating `selected` prop externally moves the cursor', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 30 }, (_, i) => i);
+    const [sel, setSel] = s.createSignal(0);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={sel()}
+        width={CONTAINER_W}
+        height={ITEM_H}
+        autofocus
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    setSel(7);
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.cursor, 7);
+    dispose();
+  });
+
+  v.test('wrap mode produces a window when scrolling past the end', async () => {
+    let virtualRef!: NavigableElement;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef as unknown as lng.ElementNode}
+        each={items}
+        selected={0}
+        width={CONTAINER_W}
+        height={ITEM_H}
+        wrap
+        autofocus
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    // Advance past the last item — cursor should wrap around to the start.
+    for (let step = 0; step < 12; step++) {
+      moveSelection(virtualRef, 1);
+      await waitForUpdate();
+    }
+
+    // 12 forward steps in a 10-item wrapped list → cursor = (0 + 12) % 10 = 2
+    v.assert.equal(virtualRef.cursor, 2);
+    dispose();
+  });
+
+  v.test('total <= window size renders every item with no slicing', async () => {
+    let virtualRef!: lng.ElementNode;
+    const items = [0, 1, 2, 3];
+
+    const dispose = renderer.render(() => (
+      <VirtualRow
+        ref={virtualRef}
+        each={items}
+        width={CONTAINER_W}
+        height={ITEM_H}
+      >
+        {(item, i) => <Poster item={item() as number} index={i()} />}
+      </VirtualRow>
+    ));
+
+    await waitForUpdate();
+
+    v.assert.equal(virtualRef.children.length, 4);
+    dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces `VirtualRow` / `VirtualColumn` with a version that derives window size from the rendered layout instead of asking the caller for it. The outer API is otherwise unchanged.

Removed props (all auto-derived now):

| Removed       | Replacement                                        |
| ------------- | -------------------------------------------------- |
| `displaySize` | `floor(container size / (first child size + gap))` |
| `bufferSize`  | `max(2, ceil(visibleCount * 0.3))`                 |
| `uniformSize` | always treated as uniform (was the default)        |
| `factorScale` | dropped; layout uses unscaled item size            |

All other props (`each`, `wrap`, `scrollIndex`, `onEndReached`, `onEndReachedThreshold`, `debugInfo`, `children`, plus inherited `scroll`/`selected`/`onSelectedChanged`) are unchanged. `VirtualGrid` is untouched.

### How it works

- On mount, a single probe item is rendered so the layout pass has something to measure.
- After the first `updateLayout()` the container's `width`/`height` and the first child's size are read; `visibleCount`, `bufferSize`, and `itemSize` are cached in a single signal.
- Once measurement completes, the full slice is rendered and the existing `computeSlice` state machine takes over — all the scroll / wrap / edge logic from before is preserved verbatim.
- Item size is assumed uniform for the lifetime of the component. Callers swapping to a differently-sized dataset should remount.

### Behavior changes (beyond the removed props)

- Callers must give the Virtual element a measurable `width` (Row) or `height` (Column) on first layout — either explicit, or sized by a flex parent. If the container has no size on the first measurement attempt, the effect re-runs when `each` updates.
- First paint shows one probe item; the full window appears on the next microtask.
- `onEndReached` is now **latched**: it fires once when the cursor crosses the threshold, re-arms when the cursor leaves the zone or `each` changes. Previously it fired on every keypress inside the zone, so callers doing infinite scroll got duplicate fetches.
- `flexBoundary='fixed'` is now set on the container, and the default styles no longer include `flexWrap: wrap` or the `y` transition.

## Context: what users are hitting with Virtual today

Two open community PRs (both against the wrap logic this PR carries over verbatim) are worth reading alongside this one — teams are patching these locally in their own libs while they wait:

- [#24](https://github.com/solid-tv/solid/pull/24) — with `wrap` and `Config.animationsEnabled === false`, every keypress overshoots the scroll position. Root cause: the non-animated path in `onSelectedChanged` applies `shiftBy` on top of a stale container position instead of first normalizing via `prevChildPos - active[axis]` like the animated path does. **This PR preserves that bug** because it keeps `onSelectedChanged` unchanged; it should either rebase on #24 or absorb the one-line fix.
- [#25](https://github.com/solid-tv/solid/pull/25) — `wrap` applies its left-buffer offset immediately on mount, which looks wrong for a "first time on the page" state and makes an initial left press jump to the last item. The proposed `skipInitialWrap` defers wrap until the user first navigates. This PR keeps the same `doOnce` mount-offset effect, so it neither fixes nor conflicts with the desire — but it will merge-conflict with #25's implementation.

The common thread: the incremental, mutation-based scroll bookkeeping (`shiftBy`, `originalPosition`, `targetPosition`, `doOnce`, `atStart`) is where all the user-reported wrap bugs live. Deriving `visibleCount` automatically is nice, but it doesn't touch the part of Virtual that is actually costing users time.

## Known issues in this PR (to fix before merge)

- [ ] **Build break**: `src/primitives/index.ts` adds `export * from './Rail.jsx'`, but `Rail.jsx` does not exist on this branch — leftover from another branch. Remove it (keep the withScrolling/handleNavigation reorder, which is legitimate).
- [ ] **Stuck in probe mode**: measurement only retries when `each` changes. If the container is sized by a flex parent that hasn't laid out yet and the data never changes again, the component renders one item forever. Needs a retry on layout (e.g. `onLayout`) rather than only on data.
- [ ] **Pre-measurement calls are dropped**: `scrollToIndex`, `updateSelected`, and `onSelectedChanged` all silently no-op while `derivedDims()` is undefined. Apps that restore scroll position right after mount will lose the call — queue it and replay after measurement instead.
- [ ] **Docs drift**: `docs/primitives/virtual.md` says the buffer is `ceil(visibleCount * 0.25)`; the code uses `0.3`.
- [ ] **Partial-item peek**: `floor(containerSize / itemSize)` undercounts when the design intentionally shows a partial item at the edge (standard TV rail pattern). The buffer usually hides this, but `visibleCount` also drives the `total <= vc` "render everything" branch and scroll anchoring — worth a `ceil` (or `+1`) and a test.
- [ ] Dead code: commented-out `// viewRef.updateLayout();` in `measureAndInit`.

## Ideas to simplify further

1. **Make container position derived, not accumulated.** Replace the incremental `shiftBy` mutations with one absolute formula: `position = base - windowOffset * itemSize`. The animated path animates to that target; the non-animated path assigns it. One code path, and the entire class of stale-position bugs from #24 becomes impossible — no more `prevChildPos - active[axis]` normalization, `originalPosition`, or `targetPosition` bookkeeping.
2. **Make `computeSlice` a pure function of `(cursor, total, vc, buf, scrollIndex, mode, wrap)`.** Today it's a state machine over `prev` with `delta`, `atStart`, and `shiftBy` threading through a 3-mode × wrap switch. Start position is derivable directly: anchor the cursor at `scrollIndex` (or the edge), clamp or `mod`, and `selected = cursor - start`. That deletes most of the switch and makes the slice trivially testable.
3. **Keep `displaySize` as an optional override.** When provided: no probe phase, no measurement, works with unmeasurable containers, and existing callers migrate with zero changes. When omitted: derive as this PR does. This turns a breaking change into an additive one and doubles as the escape hatch for the probe-mode edge cases above.
4. **Drop the single-item probe.** Item size is knowable from the first real layout pass regardless of how many items render — render `min(each.length, smallDefault)` items immediately and correct the window after measuring. Kills the one-frame single-item flash on slow TV hardware.
5. **Absorb the wrap fixes while we're here.** Rebase on #24 (one-line fix in code this PR already reformats), and consider making #25's ask the default: don't apply the wrap offset on mount, unlock wrap on first navigation. That deletes the `doOnce` effect entirely instead of adding a prop to gate it.

## Test plan

- [ ] `npm run tsc` — currently **fails** on the missing `Rail.jsx` export; re-verify after removing it
- [x] `npm run lint` — 0 errors (warnings are pre-existing)
- [x] `npm test` — new `tests/virtual.test.tsx` covers probe phase, slice windowing, navigation, latched `onEndReached`, `scrollToIndex` clamping, wrap traversal
- [ ] Smoke-test a real app with `VirtualRow` and `VirtualColumn` to confirm one-frame measurement is imperceptible and scroll behavior matches v1
- [ ] Verify `wrap`, `scrollIndex`, and `scroll: 'edge' | 'always' | 'auto'` modes still behave as before — specifically with `Config.animationsEnabled = false` (the #24 scenario)
- [ ] Verify a Virtual sized by a flex parent (no explicit `width`/`height`) measures correctly on first layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
