### PR TITLE
refactor(core): small cleanups (isFunction, _queueDelete, isDomRendererActive)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -34,6 +34,15 @@ export const SHADERS_ENABLED =
   SOLIDTV_DISABLE_SHADERS !== true;
 
 /**
+ * True when the DOM renderer is both built in (`DOM_RENDERING`) and turned on
+ * at runtime (`Config.domRendererEnabled`). `Config.domRendererEnabled` is
+ * mutable up until the renderer starts, so this is a function rather than a
+ * constant.
+ */
+export const isDomRendererActive = () =>
+  DOM_RENDERING && Config.domRendererEnabled;
+
+/**
   RUNTIME LIGHTNING CONFIGURATION \
   This configuration can be set at runtime, but it is recommended to set it
   before running any Lightning modules to ensure consistent behavior across the application.

--- a/src/core/dom-renderer/domRendererUtils.ts
+++ b/src/core/dom-renderer/domRendererUtils.ts
@@ -2,7 +2,7 @@
 import * as lng from '@solidtv/renderer';
 import { Config } from '../config.js';
 import { DOMNode } from './domRenderer.js';
-import { isFunc } from '../utils.js';
+import { isFunction } from '../utils.js';
 
 // #region Color & Gradient Utils
 
@@ -160,7 +160,7 @@ export function applyEasing(
   easing: string | lng.TimingFunction,
   progress: number,
 ): number {
-  if (isFunc(easing)) {
+  if (isFunction(easing)) {
     return easing(progress);
   }
 

--- a/src/core/elementNode.ts
+++ b/src/core/elementNode.ts
@@ -25,7 +25,6 @@ const calculateFlex = import.meta.env?.VITE_USE_NEW_FLEX
 import {
   log,
   isArray,
-  isFunc,
   keyExists,
   isINode,
   isElementNode,
@@ -34,7 +33,12 @@ import {
   isFunction,
   spliceItem,
 } from './utils.js';
-import { Config, DOM_RENDERING, isDev, SHADERS_ENABLED } from './config.js';
+import {
+  Config,
+  isDev,
+  SHADERS_ENABLED,
+  isDomRendererActive,
+} from './config.js';
 import type {
   RendererMain,
   INode,
@@ -106,7 +110,7 @@ function runPostMutation() {
   // Phase 1: delete-flush
   if (elementDeleteQueue.length > 0) {
     for (const el of elementDeleteQueue) {
-      if (Number(el._queueDelete) < 0) {
+      if ((el._queueDelete ?? 0) < 0) {
         el.destroy();
       }
       el._queueDelete = undefined;
@@ -838,7 +842,7 @@ export class ElementNode {
     if (this.rendered) {
       if (!this.lng.shader) {
         this.lng.shader = Config.convertToShader(this, target);
-      } else if (DOM_RENDERING && Config.domRendererEnabled) {
+      } else if (isDomRendererActive()) {
         // eslint-disable-next-line no-self-assign -- lng.shader is a setter, force style update
         this.lng.shader = this.lng.shader;
       }
@@ -1104,7 +1108,7 @@ export class ElementNode {
     if (this.rendered) {
       // can be 0
       if (this.forwardFocus !== undefined) {
-        if (isFunc(this.forwardFocus)) {
+        if (isFunction(this.forwardFocus)) {
           if (this.forwardFocus.call(this, this) !== false) {
             return;
           }
@@ -1370,7 +1374,7 @@ export class ElementNode {
       const flexChanged = this.display === 'flex' && calculateFlex(this);
       layoutQueue.delete(this);
       const onLayoutChanged =
-        isFunc(this.onLayout) && this.onLayout.call(this, this);
+        isFunction(this.onLayout) && this.onLayout.call(this, this);
 
       if ((flexChanged || onLayoutChanged) && this.parent) {
         addToLayoutQueue(this.parent);
@@ -1382,7 +1386,7 @@ export class ElementNode {
           if (c.display === 'flex' && isElementNode(c)) {
             // calculating directly to prevent infinite loops recalculating parents
             calculateFlex(c);
-            isFunc(c.onLayout) && c.onLayout.call(c, c);
+            isFunction(c.onLayout) && c.onLayout.call(c, c);
             addToLayoutQueue(this);
           }
         });
@@ -1795,7 +1799,7 @@ export function shaderAccessor<T extends Record<string, any> | number>(
       if (this.rendered) {
         if (!this.lng.shader) {
           this.lng.shader = Config.convertToShader(this, target);
-        } else if (DOM_RENDERING && Config.domRendererEnabled) {
+        } else if (isDomRendererActive()) {
           // eslint-disable-next-line no-self-assign -- lng.shader is a setter, force style update
           this.lng.shader = this.lng.shader;
         }

--- a/src/core/lightningInit.ts
+++ b/src/core/lightningInit.ts
@@ -1,5 +1,5 @@
 import * as lng from '@solidtv/renderer';
-import { Config, DOM_RENDERING } from './config.js';
+import { isDomRendererActive } from './config.js';
 import { DOMRendererMain, loadFontToDom } from './dom-renderer/domRenderer.js';
 import { DomRendererMainSettings } from './dom-renderer/domRendererTypes.js';
 import { FontLoadOptions } from './intrinsicTypes.js';
@@ -14,7 +14,7 @@ export function startLightningRenderer(
   options: lng.RendererMainSettings | DomRendererMainSettings,
   rootId: string | HTMLElement = 'app',
 ) {
-  const enableDomRenderer = DOM_RENDERING && Config.domRendererEnabled;
+  const enableDomRenderer = isDomRendererActive();
 
   renderer = enableDomRenderer
     ? new DOMRendererMain(options, rootId)
@@ -23,7 +23,7 @@ export function startLightningRenderer(
 }
 
 export async function loadFonts(fonts: FontLoadOptions[]) {
-  const enableDomRenderer = DOM_RENDERING && Config.domRendererEnabled;
+  const enableDomRenderer = isDomRendererActive();
   await Promise.all(
     fonts.map((font) => {
       // WebGL — SDF

--- a/src/core/shaders.ts
+++ b/src/core/shaders.ts
@@ -18,7 +18,7 @@ export {
 };
 export { WebGlShader };
 
-import { Config, DOM_RENDERING, SHADERS_ENABLED } from './config.js';
+import { SHADERS_ENABLED, isDomRendererActive } from './config.js';
 import type { CoreShaderManager } from './intrinsicTypes.js';
 import { IRendererShaderManager } from './dom-renderer/domRendererTypes.js';
 
@@ -122,17 +122,17 @@ function toValidVec4(value: unknown): Vec4 {
 export function registerDefaultShaderRounded(
   shManager: IRendererShaderManager,
 ) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType('rounded', defaultShaderRounded);
 }
 export function registerDefaultShaderShadow(shManager: CoreShaderManager) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType('shadow', defaultShaderShadow);
 }
 export function registerDefaultShaderRoundedWithBorder(
   shManager: CoreShaderManager,
 ) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType(
       'roundedWithBorder',
       defaultShaderRoundedWithBorder,
@@ -141,7 +141,7 @@ export function registerDefaultShaderRoundedWithBorder(
 export function registerDefaultShaderRoundedWithShadow(
   shManager: CoreShaderManager,
 ) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType(
       'roundedWithShadow',
       defaultShaderRoundedWithShadow,
@@ -150,31 +150,31 @@ export function registerDefaultShaderRoundedWithShadow(
 export function registerDefaultShaderRoundedWithBorderAndShadow(
   shManager: CoreShaderManager,
 ) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType(
       'roundedWithBorderWithShadow',
       defaultShaderRoundedWithBorderAndShadow,
     );
 }
 export function registerDefaultShaderHolePunch(shManager: CoreShaderManager) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType('holePunch', defaultShaderHolePunch);
 }
 export function registerDefaultShaderRadialGradient(
   shManager: CoreShaderManager,
 ) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType('radialGradient', defaultShaderRadialGradient);
 }
 export function registerDefaultShaderLinearGradient(
   shManager: CoreShaderManager,
 ) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled))
+  if (SHADERS_ENABLED && !isDomRendererActive())
     shManager.registerShaderType('linearGradient', defaultShaderLinearGradient);
 }
 
 export function registerDefaultShaders(shManager: CoreShaderManager) {
-  if (SHADERS_ENABLED && !(DOM_RENDERING && Config.domRendererEnabled)) {
+  if (SHADERS_ENABLED && !isDomRendererActive()) {
     registerDefaultShaderRounded(shManager);
     registerDefaultShaderShadow(shManager);
     registerDefaultShaderRoundedWithBorder(shManager);

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -20,9 +20,6 @@ export function log(
   }
 }
 
-export const isFunc = (obj: unknown): obj is CallableFunction =>
-  obj instanceof Function;
-
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export const isFunction = (obj: unknown): obj is Function =>
   typeof obj === 'function';

--- a/src/primitives/useMouse.ts
+++ b/src/primitives/useMouse.ts
@@ -4,7 +4,7 @@ import {
   ElementNode,
   activeElement,
   isElementNode,
-  isFunc,
+  isFunction,
   rootNode,
 } from '../index.js';
 import { makeEventListener } from '@solid-primitives/event-listener';
@@ -128,7 +128,7 @@ function findElementByActiveElement(e: MouseEvent): ElementNode | null {
   let parent = active?.parent;
   while (parent) {
     if (
-      isFunc(parent.onMouseClick) &&
+      isFunction(parent.onMouseClick) &&
       testCollision(
         px,
         py,
@@ -167,10 +167,10 @@ function handleElementClick(
     pressedElementRef.current = null;
   }
 
-  if (isFunc(clickedElement.onMouseClick)) {
+  if (isFunction(clickedElement.onMouseClick)) {
     clickedElement.onMouseClick(e, clickedElement);
     return;
-  } else if (isFunc(clickedElement.onEnter)) {
+  } else if (isFunction(clickedElement.onEnter)) {
     clickedElement.onEnter();
     return;
   }


### PR DESCRIPTION
## Summary

Three small cleanups against `src/core`, each independent of the others.

- **`isFunc` removed; `isFunction` kept.** `core/utils.ts` exported both — `isFunc` used `obj instanceof Function`, `isFunction` used `typeof obj === 'function'`. The `typeof` form is faster (no prototype-chain walk) and was already what `focusManager.ts` used. The other 7 call sites in `elementNode.ts`, `dom-renderer/domRendererUtils.ts`, and `primitives/useMouse.ts` now match.

- **`_queueDelete` check.** The post-mutation delete-flush had `Number(el._queueDelete) < 0`, which was defensive against an uninitialized shape. The constructor now initializes `_queueDelete = undefined` explicitly, so `(el._queueDelete ?? 0) < 0` is clearer and avoids the `Number(undefined) === NaN` trap.

- **`isDomRendererActive()` helper.** The pair `DOM_RENDERING && Config.domRendererEnabled` (or its negation) was repeated 13× across `shaders.ts`, `lightningInit.ts`, and `elementNode.ts`. Replaced with a single helper exported from `config.ts`. Kept as a function (not a const) because `Config.domRendererEnabled` is mutable until the renderer starts.

## What changes for callers

Nothing — `isFunc` and `DOM_RENDERING` aren't part of the documented public API, and the behavior of every replaced expression is identical. `isDomRendererActive` is a new export.

## Test plan

- [x] `npm run tsc` — clean
- [x] `npm test` — 120/120 pass
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)