### PR TITLE
refactor(focus): split propagateKeyPress into phase helpers

### DIFF
--- a/src/core/focusManager.ts
+++ b/src/core/focusManager.ts
@@ -273,6 +273,104 @@ const updateFocusPath = (
 let lastGlobalKeyPressTime = 0;
 let lastInputKey: string | number | undefined;
 
+const isElementThrottled = (
+  elm: ElementNode,
+  sameKey: boolean,
+  currentTime: number,
+): boolean =>
+  elm.throttleInput !== undefined &&
+  sameKey &&
+  elm._lastAnyKeyPressTime !== undefined &&
+  currentTime - elm._lastAnyKeyPressTime < elm.throttleInput;
+
+// Walk focus path root→leaf. Returns true if a capture handler claimed the
+// event (or an element on the path is currently rate-limited).
+const runCapturePhase = (
+  fp: ElementNode[],
+  e: KeyboardEvent,
+  mappedEvent: string | undefined,
+  isUp: boolean,
+  sameKey: boolean,
+  currentTime: number,
+): boolean => {
+  const finalFocusElm = fp[0]!;
+  const keyBase = mappedEvent || e.key;
+  const captureEvent = `onCapture${keyBase}${isUp ? 'Release' : ''}`;
+  const captureKey = isUp ? 'onCaptureKeyRelease' : 'onCaptureKey';
+
+  for (let i = fp.length - 1; i >= 0; i--) {
+    const elm = fp[i]!;
+    if (isElementThrottled(elm, sameKey, currentTime)) return true;
+
+    const captureHandler = elm[captureEvent] || elm[captureKey];
+    if (
+      isFunction(captureHandler) &&
+      captureHandler.call(elm, e, elm, finalFocusElm, mappedEvent) === true
+    ) {
+      elm._lastAnyKeyPressTime = currentTime;
+      return true;
+    }
+  }
+  return false;
+};
+
+// Walk focus path leaf→root. Returns whether the event was handled and the
+// last element that had *any* matching handler (for the no-handler debug log).
+const runBubblePhase = (
+  fp: ElementNode[],
+  e: KeyboardEvent,
+  mappedEvent: string | undefined,
+  isHold: boolean,
+  isUp: boolean,
+  sameKey: boolean,
+  currentTime: number,
+): { handled: boolean; lastHandlerSeen: ElementNode | undefined } => {
+  const finalFocusElm = fp[0]!;
+  const eventHandlerKey = mappedEvent
+    ? isUp
+      ? `on${mappedEvent}Release`
+      : `on${mappedEvent}`
+    : undefined;
+  const fallbackHandlerKey: 'onKeyHold' | 'onKeyPress' | undefined = isUp
+    ? undefined
+    : isHold
+      ? 'onKeyHold'
+      : 'onKeyPress';
+
+  let lastHandlerSeen: ElementNode | undefined;
+
+  for (let i = 0; i < fp.length; i++) {
+    const elm = fp[i]!;
+    if (isElementThrottled(elm, sameKey, currentTime)) {
+      return { handled: true, lastHandlerSeen };
+    }
+
+    let handled = false;
+    if (eventHandlerKey) {
+      const eventHandler = elm[eventHandlerKey];
+      if (isFunction(eventHandler)) {
+        lastHandlerSeen = elm;
+        handled = eventHandler.call(elm, e, elm, finalFocusElm) === true;
+      }
+    }
+    if (!handled && fallbackHandlerKey) {
+      const fallbackHandler = elm[fallbackHandlerKey];
+      if (isFunction(fallbackHandler)) {
+        lastHandlerSeen = elm;
+        handled =
+          fallbackHandler.call(elm, e, mappedEvent, elm, finalFocusElm) ===
+          true;
+      }
+    }
+
+    if (handled) {
+      elm._lastAnyKeyPressTime = currentTime;
+      return { handled: true, lastHandlerSeen };
+    }
+  }
+  return { handled: false, lastHandlerSeen };
+};
+
 const propagateKeyPress = (
   e: KeyboardEvent,
   mappedEvent?: string,
@@ -299,111 +397,35 @@ const propagateKeyPress = (
     lastGlobalKeyPressTime = currentTime;
   }
 
-  // Record the key for focus-history attribution (keyup presses don't trigger focus changes)
+  // Keyup events don't trigger focus changes, so don't record their key.
   if (!isUp) {
     _pendingHistoryKey = { keyPressed: key, mappedKey: mappedEvent };
   }
 
   const fp = focusPath();
-  const numItems = fp.length;
-  if (numItems === 0) return false;
+  if (fp.length === 0) return false;
 
-  let handlerAvailable: ElementNode | undefined;
-  const finalFocusElm = fp[0]!;
-  const keyBase = mappedEvent || e.key;
-  const captureEvent = `onCapture${keyBase}${isUp ? 'Release' : ''}`;
-  const captureKey = isUp ? 'onCaptureKeyRelease' : 'onCaptureKey';
-
-  for (let i = numItems - 1; i >= 0; i--) {
-    const elm = fp[i]!;
-
-    // Check throttle for capture phase
-    if (elm.throttleInput) {
-      if (
-        sameKey &&
-        elm._lastAnyKeyPressTime !== undefined &&
-        currentTime - elm._lastAnyKeyPressTime < elm.throttleInput
-      ) {
-        return true;
-      }
-    }
-
-    const captureHandler = elm[captureEvent] || elm[captureKey];
-    if (
-      isFunction(captureHandler) &&
-      captureHandler.call(elm, e, elm, finalFocusElm, mappedEvent) === true
-    ) {
-      elm._lastAnyKeyPressTime = currentTime;
-      return true;
-    }
+  if (runCapturePhase(fp, e, mappedEvent, isUp, sameKey, currentTime)) {
+    return true;
   }
 
-  let eventHandlerKey: string | undefined;
-  let fallbackHandlerKey: 'onKeyHold' | 'onKeyPress' | undefined;
-
-  if (mappedEvent) {
-    eventHandlerKey = isUp ? `on${mappedEvent}Release` : `on${mappedEvent}`;
-  }
-
-  if (!isUp) {
-    fallbackHandlerKey = isHold ? 'onKeyHold' : 'onKeyPress';
-  }
-
-  for (let i = 0; i < numItems; i++) {
-    const elm = fp[i]!;
-
-    // Check throttle for bubbling phase
-    if (elm.throttleInput) {
-      if (
-        sameKey &&
-        elm._lastAnyKeyPressTime !== undefined &&
-        currentTime - elm._lastAnyKeyPressTime < elm.throttleInput
-      ) {
-        return true;
-      }
-    }
-
-    let handled = false;
-
-    if (eventHandlerKey) {
-      const eventHandler = elm[eventHandlerKey];
-      if (isFunction(eventHandler)) {
-        handlerAvailable = elm;
-        if (eventHandler.call(elm, e, elm, finalFocusElm) === true) {
-          handled = true;
-        }
-      }
-    }
-
-    // Check for the fallback handler if its key is defined and not already handled by specific key handler
-    if (!handled && fallbackHandlerKey) {
-      const fallbackHandler = elm[fallbackHandlerKey];
-      if (isFunction(fallbackHandler)) {
-        handlerAvailable = elm;
-        if (
-          fallbackHandler.call(elm, e, mappedEvent, elm, finalFocusElm) === true
-        ) {
-          handled = true;
-        }
-      }
-    }
-
-    if (handled) {
-      elm._lastAnyKeyPressTime = currentTime;
-      return true;
-    }
-  }
+  const { handled, lastHandlerSeen } = runBubblePhase(
+    fp,
+    e,
+    mappedEvent,
+    isHold,
+    isUp,
+    sameKey,
+    currentTime,
+  );
+  if (handled) return true;
 
   if (isDev && Config.keyDebug && !isUp) {
-    if (handlerAvailable) {
-      console.log(
-        `Keypress bubbled, key="${e.key}", mappedEvent=${mappedEvent}, isHold=${isHold}, isUp=${isUp}`,
-        handlerAvailable,
-      );
+    const detail = `key="${e.key}", mappedEvent=${mappedEvent}, isHold=${isHold}, isUp=${isUp}`;
+    if (lastHandlerSeen) {
+      console.log(`Keypress bubbled, ${detail}`, lastHandlerSeen);
     } else {
-      console.log(
-        `No event handler available for keypress: key="${e.key}", mappedEvent=${mappedEvent}, isHold=${isHold}, isUp=${isUp}`,
-      );
+      console.log(`No event handler available for keypress: ${detail}`);
     }
   }
 


### PR DESCRIPTION
## Summary

`propagateKeyPress` had grown to 135 lines with two near-identical throttle checks (one per loop) and two distinct sub-algorithms inlined. Pull them apart:

- **`isElementThrottled(elm, sameKey, currentTime)`** — single source of truth for per-element rate-limiting. Previously copy-pasted across the capture and bubble loops as a 9-line `if (elm.throttleInput) { if (sameKey && ...) return true; }` block.
- **`runCapturePhase(...)`** — root→leaf walk, returns whether propagation should stop.
- **`runBubblePhase(...)`** — leaf→root walk, returns `{ handled, lastHandlerSeen }` so the debug log keeps its "which element had a handler but didn't claim" output without a function-scope mutable.

`propagateKeyPress` is now a flat orchestrator: global throttle → history record → capture → bubble → debug log. The orchestrator body drops from ~135 lines to ~50.

## Behavior

Unchanged. Same handler-firing order, same throttle semantics, same debug-log messages (just with the message body interpolated once instead of twice). All 120 tests pass.

## Test plan

- [x] `npm run tsc` — clean
- [x] `npm test` — 120/120 pass
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)