### PR TITLE
feat: Add ability to scroll to index without setting focus to child

### DIFF
--- a/src/primitives/Column.tsx
+++ b/src/primitives/Column.tsx
@@ -20,10 +20,12 @@ const ColumnStyles: NodeStyles = {
   gap: 30,
 };
 
-function scrollToIndex(this: ElementNode, index: number) {
+function scrollToIndex(this: ElementNode, index: number, options?: {noFocus?: boolean}) {
   this.selected = index;
   scrollColumn(index, this);
-  this.children[index]?.setFocus();
+  if (!options?.noFocus) {
+    this.children[index]?.setFocus();
+  }
 }
 
 const onUp = handleNavigation('up');

--- a/src/primitives/Lazy.tsx
+++ b/src/primitives/Lazy.tsx
@@ -136,9 +136,9 @@ function createLazy<T>(
     Array.isArray(props.each) ? props.each.slice(0, offset()) : [],
   );
 
-  function lazyScrollToIndex(this: lngp.NavigableElement, index: number) {
+  function lazyScrollToIndex(this: lngp.NavigableElement, index: number, options?: {noFocus?: boolean}) {
     setOffset(Math.max(index, 0) + buffer())
-    queueMicrotask(() => viewRef.scrollToIndex(index));
+    queueMicrotask(() => viewRef.scrollToIndex(index, options));
   }
 
   const updateOffset = (_event: KeyboardEvent, container: lng.ElementNode) => {

--- a/src/primitives/Row.tsx
+++ b/src/primitives/Row.tsx
@@ -19,10 +19,12 @@ const RowStyles: NodeStyles = {
   gap: 30,
 };
 
-function scrollToIndex(this: ElementNode, index: number) {
+function scrollToIndex(this: ElementNode, index: number, options?: {noFocus?: boolean}) {
   this.selected = index;
   scrollRow(index, this);
-  this.children[index]?.setFocus();
+  if (!options?.noFocus) {
+    this.children[index]?.setFocus();
+  }
 }
 
 const onLeft = handleNavigation('left');

--- a/src/primitives/types.ts
+++ b/src/primitives/types.ts
@@ -74,7 +74,11 @@ export interface NavigableProps extends NodeProps {
 // @ts-expect-error animationSettings is not identical - weird
 export interface NavigableElement extends ElementNode, NavigableProps {
   selected: number;
-  scrollToIndex: (this: NavigableElement, index: number) => void;
+  scrollToIndex: (
+    this: NavigableElement,
+    index: number,
+    options?: { noFocus?: boolean },
+  ) => void;
 }
 
 export interface NavigableStyleProperties {


### PR DESCRIPTION
Allows to externally scroll a row and column, without giving focus to it