### PR TITLE
fix: position calculation in createVirtual function with animations disabled

### DIFF
--- a/src/primitives/Virtual.tsx
+++ b/src/primitives/Virtual.tsx
@@ -459,7 +459,7 @@ function createVirtual<T>(
           },
         ).start();
       } else {
-        this.lng[axis] = this.lng[axis]! + childSize * slice().shiftBy;
+        this.lng[axis] = (prevChildPos - active[axis]) + childSize * slice().shiftBy;
       }
     });
   };


### PR DESCRIPTION
## Problem

When `wrap` is enabled on a `VirtualRow`/`VirtualColumn` and `Config.animationsEnabled` is `false`, navigating through the carousel causes the container to scroll more than expected on every keypress. The selected tile highlight moves correctly while the row visually overshoots.

## Root cause

The `onSelectedChanged` handler has two code paths — one animated, one not. The animation path correctly resets the container to an absolute position before applying the wrap shift:

```js
this.lng[axis] = prevChildPos - active[axis];  // reset to correct position
targetPosition = this.lng[axis] + childSize * slice().shiftBy;
this.animate(...).start();
```

The non-animation path was missing this reset:

```js
this.lng[axis] = this.lng[axis]! + childSize * slice().shiftBy;
```

When wrap navigation occurs, virtual children are repositioned in the DOM, which changes `active[axis]` — the focused child's local offset within the container. Without first normalising `this.lng[axis]` via `prevChildPos - active[axis]`, the shift is applied on top of an already-stale container position, causing a double-scroll.

## Fix

```js
- this.lng[axis] = this.lng[axis]! + childSize * slice().shiftBy;
+ this.lng[axis] = (prevChildPos - active[axis]) + childSize * slice().shiftBy;
```