### PR TITLE
[bugfix] Lazy components empty content handling

### DIFF
--- a/src/primitives/Lazy.tsx
+++ b/src/primitives/Lazy.tsx
@@ -144,7 +144,7 @@ function createLazy<T>(
   const updateOffset = (_event: KeyboardEvent, container: lng.ElementNode) => {
     const maxOffset = props.each ? props.each.length : 0;
     const selected = container.selected || 0;
-    const rendered = offset(); // == container.children.length
+    const rendered = container.children?.length || 0;
 
     // Already mounted everything, or still far enough from the rendered edge
     // that the buffer covers the next selection — no work to do.


### PR DESCRIPTION
This small change makes it easier to manage the case where there are empty items in the LazyColumn or LazyRow. 

When a child is removed from the rendering tree, it messes up with the indexing, resulting in cases where navigating down will not load new children. 

This MR fixes it by making the decision to increase the offset consider the actual number of children rendered.

Thanks ! 