### PR TITLE
fix: load canvas fonts also when using webgl renderer

### DIFF
--- a/src/core/lightningInit.ts
+++ b/src/core/lightningInit.ts
@@ -41,7 +41,7 @@ export async function loadFonts(fonts: FontLoadOptions[]) {
       if ('fontUrl' in font) {
         if (enableDomRenderer) {
           loadFontToDom(font);
-        } else if (renderer.stage.renderer.mode !== 'webgl') {
+        } else {
           return renderer.stage.loadFont('canvas', font);
         }
       }


### PR DESCRIPTION
At the moment on the renderer side the canvas text renderer is created but the fonts are not loaded, so renderText does not work.
Solution : allow the loading of canvas fonts when using any non-dom renderer