### PR TITLE
fix(announcer): keep aria live-region label until next announcement (fixes #31)

### DIFF
--- a/src/primitives/announcer/speech.ts
+++ b/src/primitives/announcer/speech.ts
@@ -58,12 +58,24 @@ function addChildrenToAriaDiv(phrase: AriaLabel) {
  * @description This function is triggered finally when the speak series is finished and we are to speak the aria labels
  */
 function focusElementForAria() {
+  // Nothing new to announce (e.g. a canceled series). Leave whatever the live
+  // region currently holds in place so an in-progress screen reader isn't cut off.
+  if (ariaLabelPhrases.length === 0) {
+    return;
+  }
+
   const element = createAriaElement();
 
   if (!element) {
     console.error(`ARIA div not found: ${ARIA_PARENT_ID}`);
     return;
   }
+
+  // Replace-on-next-write: drop the previous announcement's nodes, then inject
+  // the current label. The label stays in the assertive live region until the
+  // *next* announcement replaces it — rather than being torn down on a timer —
+  // so on-device TV screen readers have time to finish reading it.
+  cleanAriaLabelParent();
 
   for (const object of ariaLabelPhrases) {
     const span = document.createElement('span');
@@ -74,12 +86,7 @@ function focusElementForAria() {
     element.appendChild(span);
   }
 
-  // Cleanup
-  setTimeout(() => {
-    ariaLabelPhrases = [];
-    cleanAriaLabelParent();
-    focusCanvas();
-  }, 100);
+  ariaLabelPhrases = [];
 }
 
 /**
@@ -92,14 +99,6 @@ function cleanAriaLabelParent(): void {
       parentTag.removeChild(parentTag.firstChild);
     }
   }
-}
-
-/**
- * @description Focus the canvas element
- */
-function focusCanvas(): void {
-  const canvas = document.getElementById('app')?.firstChild as HTMLElement;
-  canvas?.focus();
 }
 
 /**
@@ -299,19 +298,14 @@ function speakSeries(
 
       if (root) {
         if (aria) {
-          const element = createAriaElement();
-
-          if (element) {
-            ariaLabelPhrases = [];
-            cleanAriaLabelParent();
-            element.focus();
-            focusCanvas();
-          }
-
-          return;
+          // Replace-on-next-write: don't tear down the live region here. The
+          // current label stays until the next announcement replaces it, so the
+          // screen reader can finish. Just drop any partially accumulated
+          // phrases from this canceled series.
+          ariaLabelPhrases = [];
+        } else {
+          synth.cancel(); // Cancel all ongoing speech
         }
-
-        synth.cancel(); // Cancel all ongoing speech
       }
       nestedSeriesResults.forEach((nestedSeriesResult) => {
         nestedSeriesResult.cancel();

--- a/tests/announcer-aria.spec.ts
+++ b/tests/announcer-aria.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import speak from '../src/primitives/announcer/speech.ts';
+
+const ARIA_PARENT_ID = 'aria-parent';
+
+function ariaParent(): HTMLElement | null {
+  return document.getElementById(ARIA_PARENT_ID);
+}
+
+function ariaLabels(): string[] {
+  const parent = ariaParent();
+  if (!parent) return [];
+  return Array.from(parent.querySelectorAll('span')).map(
+    (span) => span.getAttribute('aria-label') ?? '',
+  );
+}
+
+describe('Announcer aria mode (replace-on-next-write)', () => {
+  beforeEach(() => {
+    // Start each test from a clean DOM. The aria region is a module-level
+    // singleton appended to <body>, so reset it explicitly.
+    ariaParent()?.remove();
+  });
+
+  it('injects the label into the assertive live region', async () => {
+    await speak(['Hello', 'button'], true).series;
+
+    const parent = ariaParent();
+    expect(parent).toBeTruthy();
+    expect(parent!.getAttribute('aria-live')).toBe('assertive');
+
+    const labels = ariaLabels();
+    expect(labels.length).toBe(1);
+    expect(labels[0]).toContain('Hello');
+    expect(labels[0]).toContain('button');
+  });
+
+  it('leaves the label in place well past the old 100ms teardown window', async () => {
+    await speak(['Persisted label'], true).series;
+    expect(ariaLabels()[0]).toContain('Persisted label');
+
+    // The previous implementation deleted the nodes after 100ms, so an
+    // on-device screen reader never got to read them. Verify they survive.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(ariaLabels().length).toBe(1);
+    expect(ariaLabels()[0]).toContain('Persisted label');
+  });
+
+  it('replaces the previous label on the next announcement', async () => {
+    await speak(['First message'], true).series;
+    expect(ariaLabels()[0]).toContain('First message');
+
+    await speak(['Second message'], true).series;
+
+    const labels = ariaLabels();
+    expect(labels.length).toBe(1);
+    expect(labels[0]).toContain('Second message');
+    expect(labels[0]).not.toContain('First message');
+  });
+
+  it('does not wipe the live region when a follow-up series is canceled', async () => {
+    await speak(['Keep me'], true).series;
+    expect(ariaLabels()[0]).toContain('Keep me');
+
+    const next = speak(['Should not appear'], true);
+    next.cancel();
+    await next.series;
+
+    // The canceled series must not blank out the region; the prior label stays
+    // until a real announcement replaces it.
+    const labels = ariaLabels();
+    expect(labels.length).toBe(1);
+    expect(labels[0]).toContain('Keep me');
+    expect(labels[0]).not.toContain('Should not appear');
+  });
+});


### PR DESCRIPTION
Fixes #31.

## Problem

In aria mode (`Announcer.aria = true`), `focusElementForAria()` injected the focus label into the `#aria-parent` `aria-live="assertive"` region, then a hard-coded `setTimeout(…, 100)` **deleted those nodes and moved focus back to the canvas**. On webOS/Samsung TV screen readers (Audio Guidance), that teardown fires before the reader has finished — often before it has started — so **nothing is announced**, even though the DOM mutates exactly as expected. The `cancel()` path did the same immediate clear + `focusCanvas()`.

## Fix — proposed option #1 (replace-on-next-write)

The live region now holds the current label until the **next** announcement replaces it, instead of being torn down on a timer:

- **`focusElementForAria()`** — removed the 100ms teardown timer. The region is cleared (`cleanAriaLabelParent()`) immediately before the new spans are injected, so it always contains exactly the current label and the reader is never interrupted. Added an early return when there are no phrases to write, so a canceled/empty series can't blank out a label the reader is still speaking.
- **`cancel()` (aria path)** — no longer clears the DOM region or moves focus. It drops any partially-accumulated phrases and falls through to actually stop the series (`active = false`, cancel nested) instead of returning early.
- Removed the now-unused `focusCanvas()` helper — no focus is moved at all anymore, which also avoids focus changes interrupting the reader.

## Tests

Added `tests/announcer-aria.spec.ts` covering:
- label is injected into the assertive live region;
- label survives well past the old 100ms window;
- the next announcement replaces the prior label (region holds only one);
- a canceled follow-up series does not wipe the region.

All 4 pass; `tsc`, ESLint, and Prettier are clean. (The pre-existing `flex.performance.spec.ts` timing benchmark can flake under load and is unrelated to this change.)

## Reviewer note

This slightly changes `cancel()` semantics in aria mode: the series now actually halts (`active = false` / cancels nested) instead of returning early. That is more correct, but flagging in case anything relied on the old early-return behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)