### PR TITLE
fix: canvas raw shader access

### DIFF
--- a/src/core/elementNode.ts
+++ b/src/core/elementNode.ts
@@ -1620,7 +1620,11 @@ export class ElementNode {
       }
 
       // Can you put effects on Text nodes? Need to confirm...
-      if (SHADERS_ENABLED && props.shader && !props.shader.program) {
+      if (
+        SHADERS_ENABLED &&
+        props.shader &&
+        !('program' in props.shader || 'render' in props.shader) // If not a raw shader
+      ) {
         props.shader = Config.convertToShader(node, props.shader);
       }
 
@@ -1675,7 +1679,11 @@ export class ElementNode {
         }
       }
 
-      if (SHADERS_ENABLED && props.shader && !props.shader.program) {
+      if (
+        SHADERS_ENABLED &&
+        props.shader &&
+        !('program' in props.shader || 'render' in props.shader) // If not a raw shader
+      ) {
         props.shader = Config.convertToShader(node, props.shader);
       }
 


### PR DESCRIPTION
**Problem**: **Raw canvas** shaders still go through the `convertToShader` function when being set on each node. However raw shaders already contain all the info for the shader to be rendered in the `shader` prop. 
This is due to an error in the logic flow for Canvas (in WebGL it is correctly managed).

**Solution**: Apply the same logic that is used in WebGL, that is: when dealing with a raw canvas shader (`props.shader.render` is defined) do not call `convertToShader`.