### PR TITLE
fix(announcer): swallow benign speech interruptions

### DIFF
--- a/src/primitives/announcer/speech.ts
+++ b/src/primitives/announcer/speech.ts
@@ -17,7 +17,15 @@ type AriaLabel = { text: string; lang: string };
 const ARIA_PARENT_ID = 'aria-parent';
 let ariaLabelPhrases: AriaLabel[] = [];
 
-/* global SpeechSynthesisErrorEvent */
+// An Error carrying the structured speech-synthesis error code (e.g.
+// "interrupted", "canceled", "network"). We reject with this instead of the
+// raw SpeechSynthesisErrorEvent so callers can classify the failure without
+// depending on the SpeechSynthesisErrorEvent global, which isn't defined on
+// every TV browser.
+interface SpeechError extends Error {
+  error?: string;
+}
+
 function flattenStrings(series: SpeechType[] = []): SpeechType[] {
   const flattenedSeries = [];
 
@@ -153,11 +161,48 @@ function speak(
       resolve();
     };
     utterance.onerror = (e) => {
-      reject(new Error(`Speech synthesis error: ${e.error}`));
+      const error: SpeechError = new Error(
+        `Speech synthesis error: ${e.error}`,
+      );
+      // Preserve the code so speakSeries can tell benign interruptions
+      // ("interrupted"/"canceled") apart from real failures ("network", etc.).
+      error.error = e.error;
+      reject(error);
     };
     utterances.push(utterance);
     synth.speak(utterance);
   });
+}
+
+/**
+ * @description Classify a caught speech error and apply back-off.
+ * Returns the retries remaining after handling. `interrupted`/`canceled` are
+ * benign — a newer announcement cancelled or replaced the in-flight one (see
+ * synth.cancel()), which happens constantly during directional navigation — so
+ * we stop retrying without surfacing them. `network` errors back off and retry.
+ * Anything else is genuinely unexpected and is rethrown.
+ */
+async function handleSpeechError(
+  e: unknown,
+  retriesLeft: number,
+  totalRetries: number,
+): Promise<number> {
+  const code = (e as SpeechError | undefined)?.error;
+
+  if (code === 'network') {
+    retriesLeft--;
+    console.warn(
+      `Speech synthesis network error. Retries left: ${retriesLeft}`,
+    );
+    await delay(500 * (totalRetries - retriesLeft));
+    return retriesLeft;
+  }
+
+  if (code === 'canceled' || code === 'interrupted') {
+    return 0; // benign — stop retrying, don't propagate
+  }
+
+  throw e;
 }
 
 function speakSeries(
@@ -203,25 +248,11 @@ function speakSeries(
               else await speak(phrase, utterances, lang, voice);
               retriesLeft = 0; // Exit retry loop on success
             } catch (e) {
-              if (e instanceof SpeechSynthesisErrorEvent) {
-                if (e.error === 'network') {
-                  retriesLeft--;
-                  console.warn(
-                    `Speech synthesis network error. Retries left: ${retriesLeft}`,
-                  );
-                  await delay(500 * (totalRetries - retriesLeft));
-                } else if (
-                  e.error === 'canceled' ||
-                  e.error === 'interrupted'
-                ) {
-                  // Cancel or interrupt error (ignore)
-                  retriesLeft = 0;
-                } else {
-                  throw new Error(`SpeechSynthesisErrorEvent: ${e.error}`);
-                }
-              } else {
-                throw e;
-              }
+              retriesLeft = await handleSpeechError(
+                e,
+                retriesLeft,
+                totalRetries,
+              );
             }
           }
         } else if (phrase instanceof SpeechSynthesisUtterance) {
@@ -241,25 +272,11 @@ function speakSeries(
                 retriesLeft = 0; // Exit retry loop on success
               }
             } catch (e) {
-              if (e instanceof SpeechSynthesisErrorEvent) {
-                if (e.error === 'network') {
-                  retriesLeft--;
-                  console.warn(
-                    `Speech synthesis network error. Retries left: ${retriesLeft}`,
-                  );
-                  await delay(500 * (totalRetries - retriesLeft));
-                } else if (
-                  e.error === 'canceled' ||
-                  e.error === 'interrupted'
-                ) {
-                  // Cancel or interrupt error (ignore)
-                  retriesLeft = 0;
-                } else {
-                  throw new Error(`SpeechSynthesisErrorEvent: ${e.error}`);
-                }
-              } else {
-                throw e;
-              }
+              retriesLeft = await handleSpeechError(
+                e,
+                retriesLeft,
+                totalRetries,
+              );
             }
           }
         } else if (typeof phrase === 'function') {


### PR DESCRIPTION
## What

`Error: Speech synthesis error: interrupted` was spamming the console during directional navigation. This makes the announcer correctly treat speech `interrupted`/`canceled` as the benign, expected events they are.

## Why

The error originates in `speak()`'s `utterance.onerror` ([speech.ts](src/primitives/announcer/speech.ts)). `interrupted`/`canceled` fire on **every** normal announcement, because each new announcement calls `synth.cancel()` to replace the in-flight one.

`speakSeries` already *intended* to swallow these, but the swallow branch was gated on `e instanceof SpeechSynthesisErrorEvent` — while `speak()` rejected a plain `Error`. So:

- the `instanceof` check was always false → the error hit `else { throw e }`,
- which rejected the `series` promise,
- which, on the non-`notification` announce path (never `.catch`ed), surfaced as an unhandled rejection in the console.

The same dead branch also defeated the `network` retry logic, and `SpeechSynthesisErrorEvent` isn't defined as a global on every TV browser (a `ReferenceError` waiting to happen if the branch ever evaluated).

## Changes

- `speak()` now rejects an `Error` that carries the structured `.error` code.
- Added a single `handleSpeechError()` classifier (replacing two copy-pasted catch blocks) that classifies by the `.error` code string:
  - `interrupted`/`canceled` → stop retrying silently (no longer surfaced),
  - `network` → back off and retry (this path was also dead before),
  - anything unexpected → rethrow.
- Dropped the dependency on the `SpeechSynthesisErrorEvent` global.

## Reviewer notes

- A *genuinely* unexpected speech error (e.g. `synthesis-failed`) on the non-`notification` path still has no `.catch` in `announcer.ts`, so it would be an unhandled rejection. That's now rare and arguably *should* be visible — happy to add a `.catch` safety net on the returned `series` if preferred.

## Verification

- `npm run tsc` — clean
- `npm run lint` — 0 errors (`speech.ts` introduces no new warnings)
- `npm run test` — 124/124 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)