### PR TITLE
feat(flex): warn in dev when justifyContent requires an explicit width

### DIFF
--- a/src/core/elementNode.ts
+++ b/src/core/elementNode.ts
@@ -1649,6 +1649,23 @@ export class ElementNode {
             const isFlexRow =
               flexDirection === 'row' || flexDirection === 'row-reverse';
             flexFitsWidth = isFlexRow && node.flexBoundary !== 'fixed';
+
+            if (isDev && flexFitsWidth) {
+              const needsWidthForJustify = [
+                'center',
+                'flex-end',
+                'space-between',
+                'space-around',
+                'space-evenly',
+              ].includes(node.justifyContent as string);
+
+              if (needsWidthForJustify) {
+                console.warn(
+                  `justifyContent '${node.justifyContent}' requires an explicit width on the flex container; without one it shrinks to fit its children and has no free space to distribute: `,
+                  this,
+                );
+              }
+            }
           }
 
           if (node.flexGrow || flexFitsWidth) {


### PR DESCRIPTION
## What

Adds a **dev-only** `console.warn` when a flex container uses a `justifyContent` value that needs free space to distribute (`center`, `flex-end`, `space-between`, `space-around`, `space-evenly`) but has **no explicit `width`** set.

## Why

A flex row container without a width shrinks to fit its children, leaving zero free space. All five of those justify modes position children from the free space (`containerSize − totalItemSize − padding`), so with a shrink-to-fit width they have nothing to distribute and silently collapse to `flex-start`.

It's actually worse than a no-op: when no width is set, `elementNode` seeds `props.w = 0`, and the shrink-to-fit container resize only happens in the `flex-start` branch of `flexLayout.ts`. The other justify branches compute against `containerSize = 0`, producing zero/negative offsets while the container stays width 0. These modes are effectively undefined without an explicit container width that exceeds the content.

## Approach

This is an alternative to #38. Rather than silently auto-filling the parent width, it keeps the existing shrink-to-fit behavior unchanged and surfaces a diagnostic so the developer sets an explicit `width` themselves.

- Gated by `isDev` — no warning in production.
- Guarded by the existing `flexFitsWidth` condition, so it only fires when the container would actually shrink (skips `flexBoundary: 'fixed'` and column directions).
- Passes the node to `console.warn` so it's clickable to the offending element, matching other warnings in the file.

## Notes for reviewers

- Behavior is unchanged; this is purely a dev diagnostic.
- `npm run tsc` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)