### PR TITLE
fix(shaders): don't re-convert raw canvas shaders

### DIFF
--- a/src/core/elementNode.ts
+++ b/src/core/elementNode.ts
@@ -1620,7 +1620,10 @@ export class ElementNode {
       }
 
       // Can you put effects on Text nodes? Need to confirm...
-      if (SHADERS_ENABLED && props.shader && !props.shader.program) {
+      // A built shader node (WebGL, Canvas, or the DOM test fake) always has a
+      // `shaderType`; a raw StyleEffects props object never does. Only convert
+      // the latter — a built shader is already ready to render.
+      if (SHADERS_ENABLED && props.shader && !('shaderType' in props.shader)) {
         props.shader = Config.convertToShader(node, props.shader);
       }
 
@@ -1692,7 +1695,7 @@ export class ElementNode {
         }
       }
 
-      if (SHADERS_ENABLED && props.shader && !props.shader.program) {
+      if (SHADERS_ENABLED && props.shader && !('shaderType' in props.shader)) {
         props.shader = Config.convertToShader(node, props.shader);
       }
 


### PR DESCRIPTION
## Problem

Raw **Canvas** shaders still go through `convertToShader` when set on each node, even though a raw shader already carries everything it needs to render. WebGL handles this correctly; Canvas does not.

The guard in `ElementNode._render` was:

```ts
if (SHADERS_ENABLED && props.shader && !props.shader.program) {
  props.shader = Config.convertToShader(node, props.shader);
}
```

A `CanvasShaderNode` exposes `render`, not `program`, so it falls through the `!props.shader.program` check and gets wrongly re-run through `convertToShader`. WebGL only works because `WebGlShaderNode` happens to have a `program` field.

## Solution

This is an alternative to #34. Instead of widening the check to `'program' in shader || 'render' in shader` (which enumerates backend-specific fields and needs a new clause per backend), use the single field that **every** built shader shares and a raw `StyleEffects` props object never has: `shaderType`.

- `WebGlShaderNode` and `CanvasShaderNode` both extend `CoreShaderNode`, which declares `readonly shaderType`.
- The DOM-renderer test fake returns `{ shaderType, props, program: {} }`.
- `StyleEffects` (`border*`/`shadow`/`rounded`/gradients/`holePunch`) has no `shaderType`.

So `!('shaderType' in props.shader)` cleanly means "this is a raw style-props object, build a shader from it" and covers WebGL, Canvas, and the DOM test path uniformly.

### Behavior parity
| `props.shader` | has `shaderType`? | result |
| --- | --- | --- |
| WebGL node | yes | skip (same as before) |
| Canvas node | yes | **skip (fixes the bug)** |
| DOM test fake | yes | skip |
| `StyleEffects` props | no | convert |

## Verification
- `npm run tsc` — clean
- `npm test` — 134 passed
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)