### PR TITLE
fix(lazy): handle empty item content without breaking mount termination

### DIFF
--- a/src/primitives/Lazy.tsx
+++ b/src/primitives/Lazy.tsx
@@ -144,11 +144,17 @@ function createLazy<T>(
   const updateOffset = (_event: KeyboardEvent, container: lng.ElementNode) => {
     const maxOffset = props.each ? props.each.length : 0;
     const selected = container.selected || 0;
-    const rendered = offset(); // == container.children.length
+    // The rendered edge is the actual child count, not offset(): the two
+    // diverge when an item renders empty (no node inserted) or renders
+    // multiple top-level nodes. `selected` indexes into children, so the
+    // proximity check must use child units.
+    const rendered = container.children.length;
 
-    // Already mounted everything, or still far enough from the rendered edge
-    // that the buffer covers the next selection — no work to do.
-    if (rendered >= maxOffset || selected < rendered - buffer()) return;
+    // Already mounted everything (offset is in data units — a diverged child
+    // count must neither stop mounting early nor keep it running forever),
+    // or still far enough from the rendered edge that the buffer covers the
+    // next selection — no work to do.
+    if (offset() >= maxOffset || selected < rendered - buffer()) return;
 
     const bump = () => setOffset((prev) => Math.min(prev + 1, maxOffset));
 

--- a/src/primitives/VirtualGrid.tsx
+++ b/src/primitives/VirtualGrid.tsx
@@ -3,8 +3,13 @@ import * as lng from '@solidtv/solid';
 import * as lngp from '@solidtv/solid/primitives';
 import { List } from '@solid-primitives/list';
 import * as utils from '../utils.js';
+// Imported directly, not via lngp: this call runs at module init, and the
+// barrel's withScrolling binding is not yet initialized when the barrel is
+// the import entry (circular init — index.ts re-exports withScrolling after
+// VirtualGrid).
+import { withScrolling } from './utils/withScrolling.js';
 
-const columnScroll = lngp.withScrolling(false);
+const columnScroll = withScrolling(false);
 
 const rowStyles: lng.NodeStyles = {
   display: 'flex',

--- a/tests/lazy.test.tsx
+++ b/tests/lazy.test.tsx
@@ -1,0 +1,89 @@
+import * as v from 'vitest';
+import * as lng from '@solidtv/solid';
+import { LazyColumn } from '../src/primitives/Lazy.jsx';
+import { renderer } from './setup.js';
+
+const wait = (ms = 10) => new Promise((r) => setTimeout(r, ms));
+
+// updateOffset runs before moveSelection in the chained onDown handler, the
+// same order propagateKeyPress invokes it with (handler.call(elm, e, elm)).
+const pressDown = (col: lng.ElementNode) =>
+  (col as any).onDown.call(col, { key: 'ArrowDown' } as KeyboardEvent, col);
+
+v.describe('Lazy components with empty content', () => {
+  v.test('keeps mounting past items that render empty (#26)', async () => {
+    let col!: lng.ElementNode;
+    // Odd items render nothing: 10 data items, 5 rendered children total.
+    const each = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    const dispose = renderer.render(() => (
+      <view width={1920} height={1080}>
+        <LazyColumn ref={col} each={each} upCount={3} sync y={0}>
+          {(item) => (
+            <lng.Show when={item() % 2 === 0}>
+              <view width={300} height={80} />
+            </lng.Show>
+          )}
+        </LazyColumn>
+      </view>
+    ));
+    await wait();
+
+    col.setFocus();
+    await wait();
+
+    // Walk to the end of the list. 10 data items and one mount per press —
+    // a dozen presses is more than enough when the guard terminates
+    // correctly, and few enough to finish fast if it doesn't.
+    for (let i = 0; i < 12; i++) {
+      pressDown(col);
+      await wait(1);
+    }
+
+    v.assert.equal(
+      col.children.length,
+      5,
+      'all non-empty items mounted despite empty siblings',
+    );
+    v.assert.equal(col.selected, 4, 'selection reached the last child');
+
+    dispose();
+  });
+
+  v.test('multi-node item templates do not stall mounting early', async () => {
+    let col!: lng.ElementNode;
+    // Each item renders two top-level nodes, so children.length runs at
+    // twice the item count and reaches each.length before all items mount.
+    const each = [0, 1, 2, 3, 4, 5];
+
+    const dispose = renderer.render(() => (
+      <view width={1920} height={1080}>
+        <LazyColumn ref={col} each={each} upCount={2} sync y={0}>
+          {() => (
+            <>
+              <view width={300} height={80} />
+              <view width={300} height={20} skipFocus />
+            </>
+          )}
+        </LazyColumn>
+      </view>
+    ));
+    await wait();
+
+    col.setFocus();
+    await wait();
+
+    for (let i = 0; i < 16; i++) {
+      pressDown(col);
+      await wait(1);
+    }
+
+    v.assert.equal(
+      col.children.length,
+      12,
+      'every item mounted even though children outnumber data items',
+    );
+
+    dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Alternative to #26, addressing the same bug plus the issues found while reviewing it. Thanks @girouxc for the diagnosis — the core insight (the mount decision must look at `container.children.length`, because items that render empty insert no child node) is adopted here.

**The bug (#26):** when items in a `LazyRow`/`LazyColumn` render empty, `offset()` overstates the rendered edge. `selected` (an index into actual children) then never gets within `buffer` of `offset`, so `updateOffset` early-returns forever and navigation stops mounting new items — the list dead-ends.

**Why not exactly the #26 one-liner:** replacing `rendered` with `container.children.length` in *both* halves of the guard introduces two new problems, because `maxOffset` (`props.each.length`) is in data units while `children.length` is in node units:

1. **Multi-node item templates permanently stall mounting.** Solid's universal renderer flattens fragments into direct siblings, so an item rendering 2 top-level nodes doubles `children.length`. With 20 items × 2 nodes, after 10 items mount `children.length (20) >= maxOffset (20)` — the guard early-returns forever and items 11–20 can never mount.
2. **The termination guard goes dead in the empty-item case it fixes.** `children.length` never reaches `maxOffset` when any item renders empty, so once everything is mounted the guard never short-circuits; with `delay` set, every keypress at the list edge clears and re-arms `navDelayTimer` around a no-op bump, indefinitely.

**The fix:** keep each comparison in its own unit system —

```ts
const rendered = container.children.length;
if (offset() >= maxOffset || selected < rendered - buffer()) return;
```

- *Proximity* (`selected < rendered - buffer()`) uses child units, matching `selected` — this is the #26 fix.
- *Termination* (`offset() >= maxOffset`) stays in data units, immune to the child count diverging in either direction.

## Also in this PR

- **Regression tests** (`tests/lazy.test.tsx`) — there was no lazy coverage at all. One test reproduces the #26 scenario (items rendering empty; fails on `main`), one pins the multi-node-template case.
- **`VirtualGrid` barrel-init fix** — `VirtualGrid` called `lngp.withScrolling(false)` at module init through the package barrel, but `index.ts` re-exports `withScrolling` *after* `VirtualGrid`, so any import with the barrel as entry (including the new tests) threw `withScrolling is not a function`. It now imports the module directly.

## Known remaining inconsistency (out of scope)

`lazyScrollToIndex` still mixes units: it sets `offset = index + buffer` (data units) but `scrollToIndex(index)` indexes children. With empty items the target child may not exist — downstream guards (`children[index]?.setFocus()`, `withScrolling`'s bounds check) prevent a crash, but scroll/focus silently no-op. Fixing it requires mapping child indices back to data indices, which deserves its own change.

## Testing

- `npm test` — 136/136 passing (11 files), including the two new lazy tests
- New empty-content test verified to fail against the pre-fix `updateOffset`
- `npm run tsc` and `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)