### PR TITLE
fix: Patch scrollToIndex to scroll backwards

### DIFF
--- a/src/primitives/Column.tsx
+++ b/src/primitives/Column.tsx
@@ -21,8 +21,9 @@ function scrollToIndex(
   index: number,
   options?: { noFocus?: boolean },
 ): void {
+  const lastSelected = this.selected;
   this.selected = index;
-  scrollColumn(index, this);
+  scrollColumn(index, this, undefined, lastSelected === index ? undefined : lastSelected);
   if (!options?.noFocus) {
     this.children[index]?.setFocus();
   }

--- a/src/primitives/Row.tsx
+++ b/src/primitives/Row.tsx
@@ -19,9 +19,10 @@ const RowStyles: NodeStyles = {
   gap: 30,
 };
 
-function scrollToIndex(this: ElementNode, index: number, options?: {noFocus?: boolean}) {
+function scrollToIndex(this: ElementNode, index: number, options?: { noFocus?: boolean }) {
+  const lastSelected = this.selected;
   this.selected = index;
-  scrollRow(index, this);
+  scrollRow(index, this, undefined, lastSelected === index ? undefined : lastSelected);
   if (!options?.noFocus) {
     this.children[index]?.setFocus();
   }


### PR DESCRIPTION
## Problem

`Row.scrollToIndex` / `Column.scrollToIndex` always scroll forward, even when the target index is behind the current one — `selected` updates but the container never scrolls back, leaving the selected child off-screen.

**Repro:** a `Row` with `scroll="auto"` and overflowing children, scrolled forward to some index `n`; call `row.scrollToIndex(n - 1)` → `selected` becomes `n - 1` but the row's `x` doesn't move.

### Root cause

`scrollToIndex` overwrites `this.selected` and then calls the scroller without a `lastSelected`:

```js
function scrollToIndex(index, options) {
    this.selected = index;
    scrollRow(index, this);
    ...
}
```

In `withScrolling`, an undefined `lastSelected` makes the move register as incrementing (`isIncrementing = lastSelected === undefined || ...`), so the next position is always computed in the forward direction and then clamped — moving backward, the clamp leaves the container where it was. Key navigation is unaffected because `selectChild` passes `lastSelected` through `onSelectedChanged`; only programmatic `scrollToIndex` calls lose the direction.

## Fix

Capture the previous `selected` before overwriting it and pass it as `lastSelected`, so `withScrolling` resolves direction the same way it does for key navigation:

```js
function scrollToIndex(index, options) {
    const lastSelected = this.selected;
    this.selected = index;
    scrollRow(index, this, undefined, lastSelected === index ? undefined : lastSelected);
    ...
}
```

When the index is unchanged, `undefined` is still passed on purpose: `withScrolling` early-returns on `selected === lastSelected`, and some callers use `scrollToIndex` with the current index to force positioning (e.g. after layout) — this keeps that behaviour intact.

Same fix applied to `Column.scrollToIndex` with `scrollColumn`.
