### PR TITLE
fix(dom-renderer): use setAttribute for kebab-case data keys

### DIFF
--- a/src/core/dom-renderer/domRenderer.ts
+++ b/src/core/dom-renderer/domRenderer.ts
@@ -1232,7 +1232,11 @@ function updateNodeData(node: DOMNode | DOMText) {
     if (keyValue === undefined) {
       node.div.removeAttribute('data-' + key);
     } else {
-      node.div.dataset[key] = String(keyValue);
+      // dataset[key] requires key to already be camelCase (DOMStringMap rejects hyphenated
+      // property names outright, e.g. "section-id" -- SyntaxError: not a valid property
+      // name). Our data props are passed as data-attribute-style keys (kebab-case), so use
+      // setAttribute directly instead, consistent with the removeAttribute branch above.
+      node.div.setAttribute('data-' + key, String(keyValue));
     }
   }
 }


### PR DESCRIPTION
## What

`updateNodeData` in the DOM renderer wrote data props via `node.div.dataset[key]`. Switched to `node.div.setAttribute('data-' + key, ...)`.

## Why

`dataset[key]` (DOMStringMap) requires the key to already be camelCase. The spec mandates a `SyntaxError` when the property name contains a hyphen followed by an ASCII lowercase letter, so writing a kebab-case key like `section-id` **crashes `updateNodeData` in every conformant browser** — not WebOS-specific (reproduced in a regular desktop browser and in jsdom).

Our data props are passed as kebab-case, data-attribute-style keys, so `setAttribute('data-' + key, ...)` is the correct path. It's also consistent with the `removeAttribute('data-' + key)` branch right above it.

### Bonus fix

The set/remove branches were already inconsistent for **camelCase** keys (e.g. the internal `testId`):
- old set: `dataset['testId']` → wrote `data-test-id`
- remove: `removeAttribute('data-testId')` → lowercased to `data-testid` → **never matched**, so removal silently no-op'd

Routing both through the literal `'data-' + key` makes set and remove round-trip correctly.

### Reviewer note

For camelCase keys the resulting attribute name changes from the auto-kebab'd `data-test-id` to the lowercased literal `data-testid`. In practice the only internal camelCase key is `testId`, and `data-testid` is the conventional testing attribute (matches `@testing-library`'s default). Flag if any consumer queries `[data-test-id]` specifically.

## Testing

- `npm run build` — succeeds
- `npm test` — 136/136 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)