### PR TITLE
feat(fonts): start font downloads before the renderer boots

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "peerDependencies": {
     "@solidjs/router": "^0.16.1",
-    "@solidtv/renderer": "^1.5.4",
+    "@solidtv/renderer": "^1.6.3",
     "solid-js": "*"
   },
   "peerDependenciesMeta": {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.3)
       '@solidtv/renderer':
-        specifier: ^1.5.4
-        version: 1.5.4
+        specifier: ^1.6.3
+        version: 1.6.3
       solid-js:
         specifier: '*'
         version: 1.9.3
@@ -869,8 +869,8 @@ packages:
       '@solidjs/router':
         optional: true
 
-  '@solidtv/renderer@1.5.4':
-    resolution: {integrity: sha512-a3sUHHLQGAZErRr6A6CIxx1YClvtebGidjT52JIVKHKpLLNLCfhtNi/UwnMJAf1pZmZ0WL5tMB43l4xQMn5T4w==}
+  '@solidtv/renderer@1.6.3':
+    resolution: {integrity: sha512-GRm92jZtWQ5ltWlVLZ02YjFjNeaweGoXCl3tzZyw6FTHPEMwERbD/+gZVfx0xiCDmq2GsqmFpgCRY3wuMc0sQQ==}
     engines: {node: '>= 18.0.0', npm: '>= 10.0.0', pnpm: '>= 10.17.0'}
 
   '@standard-schema/spec@1.1.0':
@@ -3197,7 +3197,7 @@ snapshots:
     optionalDependencies:
       '@solidjs/router': 0.16.1(solid-js@1.9.3)
 
-  '@solidtv/renderer@1.5.4': {}
+  '@solidtv/renderer@1.6.3': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/src/core/dom-renderer/domRenderer.ts
+++ b/src/core/dom-renderer/domRenderer.ts
@@ -2279,7 +2279,7 @@ export class DOMRendererMain implements IRendererMain {
 }
 
 export function loadFontToDom(font: FontLoadOptions): void {
-  // fontFamily: string;
+  // fontFamily: string | string[];
   // metrics?: FontMetrics;
   // fontUrl?: string;
   // atlasUrl?: string;
@@ -2294,16 +2294,27 @@ export function loadFontToDom(font: FontLoadOptions): void {
     return;
   }
 
-  const fontFace = new FontFace(font.fontFamily, `url(${font.fontUrl})`);
   const fontSet = document.fonts as FontFaceSet & {
     add?: (font: FontFace) => FontFaceSet;
   };
-  fontSet.add?.(fontFace);
 
-  fontFace
-    .load()
-    .then(scheduleContainTextNodesMeasurement)
-    .catch(() => {});
+  // One load may register the same file under several family names. Each name
+  // needs its own FontFace — the browser dedupes the download by URL — so that
+  // text referring to any of them resolves. Passing the array straight to
+  // FontFace would stringify it into a single bogus family.
+  const names = Array.isArray(font.fontFamily)
+    ? font.fontFamily
+    : [font.fontFamily];
+
+  for (let i = 0; i < names.length; i++) {
+    const fontFace = new FontFace(names[i]!, `url(${font.fontUrl})`);
+    fontSet.add?.(fontFace);
+
+    fontFace
+      .load()
+      .then(scheduleContainTextNodesMeasurement)
+      .catch(() => {});
+  }
 }
 
 export function isDomRenderer(

--- a/src/core/lightningInit.ts
+++ b/src/core/lightningInit.ts
@@ -21,17 +21,52 @@ export function startLightningRenderer(
   renderer = enableDomRenderer
     ? new DOMRendererMain(options, rootId)
     : new lng.RendererMain(options, rootId);
+
+  // A stage now exists, so any fonts requested before this point can finish.
+  flushPendingFonts();
+
   return renderer;
 }
 
-export async function loadFonts(fonts: FontLoadOptions[]) {
+/**
+ * A `loadFonts()` call made before the renderer existed. The download is
+ * already in flight; only the stage-dependent half is still owed.
+ */
+interface PendingFontLoad {
+  fonts: FontLoadOptions[];
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+}
+
+const pendingFontLoads: PendingFontLoad[] = [];
+
+/**
+ * Stage-free font prefetch, added in a later renderer than the one this
+ * package requires as a peer. Resolved off the namespace rather than imported
+ * by name so an older renderer yields `undefined` instead of failing to link:
+ * fonts then simply load at attach time, as they did before.
+ */
+const prefetchFont = (
+  lng as {
+    prefetchFont?: (
+      font: Omit<FontLoadOptions, 'type'> & {
+        type?: SdfFontType | 'canvas';
+      },
+    ) => void;
+  }
+).prefetchFont;
+
+/**
+ * Hand fonts to the stage. Requires a renderer.
+ */
+function attachFonts(fonts: FontLoadOptions[]) {
   // Inlined so the loadFontToDom branch + import tree-shake in WebGL builds.
   const enableDomRenderer = DOM_RENDERING && Config.domRendererEnabled;
   const hasCanvas =
     !enableDomRenderer &&
     'textRenderers' in renderer.stage &&
     !!(renderer.stage as lng.Stage).textRenderers.canvas;
-  await Promise.all(
+  return Promise.all(
     fonts.map((font) => {
       // WebGL — SDF
       if (
@@ -51,4 +86,81 @@ export async function loadFonts(fonts: FontLoadOptions[]) {
       }
     }),
   );
+}
+
+/**
+ * Whether the app will run an SDF text engine. Read from the renderer options
+ * rather than the stage, because this has to be answerable before the renderer
+ * is constructed. Unknown (no `fontEngines` configured yet) is treated as
+ * "maybe", matching the stage's own SDF-first preference order.
+ */
+function mayUseSdf() {
+  const engines = (Config.rendererOptions as lng.RendererMainSettings)
+    ?.fontEngines;
+  if (engines === undefined || engines.length === 0) {
+    return true;
+  }
+  return engines.some((engine) => engine.type === 'sdf');
+}
+
+function flushPendingFonts() {
+  if (pendingFontLoads.length === 0) {
+    return;
+  }
+
+  const queued = pendingFontLoads.splice(0, pendingFontLoads.length);
+  for (let i = 0; i < queued.length; i++) {
+    const pending = queued[i]!;
+    attachFonts(pending.fonts).then(() => pending.resolve(), pending.reject);
+  }
+}
+
+/**
+ * Load fonts into the renderer.
+ *
+ * Can be called either side of `createRenderer()`. Calling it *first* is
+ * preferred: the downloads start immediately and overlap the renderer's boot
+ * (GL context, shaders, buffers) instead of queueing behind it. The fonts are
+ * then attached to the stage as soon as it exists.
+ *
+ * The returned promise resolves when the fonts are attached to the stage — so
+ * when called before `createRenderer()`, it cannot settle until
+ * `createRenderer()` has run. Do not `await` it before creating the renderer.
+ */
+export async function loadFonts(fonts: FontLoadOptions[]) {
+  if (renderer !== undefined) {
+    await attachFonts(fonts);
+    return;
+  }
+
+  // Inlined so the loadFontToDom branch + import tree-shake in WebGL builds.
+  const enableDomRenderer = DOM_RENDERING && Config.domRendererEnabled;
+  const preferSdf = mayUseSdf();
+  const deferred: FontLoadOptions[] = [];
+
+  for (let i = 0; i < fonts.length; i++) {
+    const font = fonts[i]!;
+
+    // The DOM path registers fonts with the document, never with a stage —
+    // there is nothing to wait for, so finish it here.
+    if (enableDomRenderer) {
+      if ('fontUrl' in font) {
+        loadFontToDom(font);
+      }
+      continue;
+    }
+
+    if (prefetchFont !== undefined) {
+      prefetchFont(preferSdf ? font : { ...font, type: 'canvas' });
+    }
+    deferred.push(font);
+  }
+
+  if (deferred.length === 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    pendingFontLoads.push({ fonts: deferred, resolve, reject });
+  });
 }

--- a/src/core/lightningInit.ts
+++ b/src/core/lightningInit.ts
@@ -1,4 +1,5 @@
 import * as lng from '@solidtv/renderer';
+import { prefetchFont } from '@solidtv/renderer';
 import { Config, DOM_RENDERING } from './config.js';
 import { DOMRendererMain, loadFontToDom } from './dom-renderer/domRenderer.js';
 import { DomRendererMainSettings } from './dom-renderer/domRendererTypes.js';
@@ -39,22 +40,6 @@ interface PendingFontLoad {
 }
 
 const pendingFontLoads: PendingFontLoad[] = [];
-
-/**
- * Stage-free font prefetch, added in a later renderer than the one this
- * package requires as a peer. Resolved off the namespace rather than imported
- * by name so an older renderer yields `undefined` instead of failing to link:
- * fonts then simply load at attach time, as they did before.
- */
-const prefetchFont = (
-  lng as {
-    prefetchFont?: (
-      font: Omit<FontLoadOptions, 'type'> & {
-        type?: SdfFontType | 'canvas';
-      },
-    ) => void;
-  }
-).prefetchFont;
 
 /**
  * Hand fonts to the stage. Requires a renderer.
@@ -150,9 +135,9 @@ export async function loadFonts(fonts: FontLoadOptions[]) {
       continue;
     }
 
-    if (prefetchFont !== undefined) {
-      prefetchFont(preferSdf ? font : { ...font, type: 'canvas' });
-    }
+    // Starts the download now; the stage-dependent half is owed until
+    // `createRenderer()` runs and `flushPendingFonts()` attaches it.
+    prefetchFont(preferSdf ? font : { ...font, type: 'canvas' });
     deferred.push(font);
   }
 

--- a/tests/loadFontToDom.test.ts
+++ b/tests/loadFontToDom.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadFontToDom } from '../src/core/dom-renderer/domRenderer.js';
+
+// The renderer's font descriptors accept `fontFamily` as an array to register
+// one file under several names. Passing that array straight to `FontFace`
+// would stringify it into a single bogus family ("Roboto,Roboto500"), so the
+// DOM path has to fan it out into one face per name.
+
+class FakeFontFace {
+  static created: FakeFontFace[] = [];
+  constructor(
+    public family: string,
+    public source: string,
+  ) {
+    FakeFontFace.created.push(this);
+  }
+  load(): Promise<FakeFontFace> {
+    return Promise.resolve(this);
+  }
+}
+
+describe('loadFontToDom', () => {
+  let added: FakeFontFace[];
+  let originalFontFace: unknown;
+  let originalFonts: unknown;
+
+  beforeEach(() => {
+    added = [];
+    FakeFontFace.created = [];
+    originalFontFace = (globalThis as unknown as { FontFace: unknown })
+      .FontFace;
+    (globalThis as unknown as { FontFace: unknown }).FontFace = FakeFontFace;
+
+    originalFonts = document.fonts;
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { add: (f: FakeFontFace) => added.push(f) },
+    });
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { FontFace: unknown }).FontFace =
+      originalFontFace;
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: originalFonts,
+    });
+  });
+
+  it('registers a single family name', () => {
+    loadFontToDom({ fontFamily: 'Roboto', fontUrl: 'roboto.woff2' });
+
+    expect(added.map((f) => f.family)).toEqual(['Roboto']);
+    expect(added[0]!.source).toBe('url(roboto.woff2)');
+  });
+
+  it('registers one face per name when given an alias list', () => {
+    loadFontToDom({
+      fontFamily: ['Roboto', 'Roboto500'],
+      fontUrl: 'roboto.woff2',
+    });
+
+    expect(added.map((f) => f.family)).toEqual(['Roboto', 'Roboto500']);
+    // Same URL for both — the browser dedupes the actual download.
+    expect(added.every((f) => f.source === 'url(roboto.woff2)')).toBe(true);
+  });
+
+  it('does nothing without a font url', () => {
+    loadFontToDom({ fontFamily: 'Roboto' });
+
+    expect(added).toEqual([]);
+    expect(FakeFontFace.created).toEqual([]);
+  });
+
+  it('survives an engine with no FontFace', () => {
+    (globalThis as unknown as { FontFace: unknown }).FontFace = undefined;
+
+    expect(() =>
+      loadFontToDom({ fontFamily: 'Roboto', fontUrl: 'roboto.woff2' }),
+    ).not.toThrow();
+    expect(added).toEqual([]);
+  });
+
+  it('swallows a failed load rather than rejecting unhandled', async () => {
+    vi.spyOn(FakeFontFace.prototype, 'load').mockRejectedValueOnce(
+      new Error('network'),
+    );
+
+    loadFontToDom({ fontFamily: 'Roboto', fontUrl: 'roboto.woff2' });
+
+    // Give the rejection a turn to surface if it were unhandled.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(added.map((f) => f.family)).toEqual(['Roboto']);
+  });
+});

--- a/tests/loadFontToDom.test.ts
+++ b/tests/loadFontToDom.test.ts
@@ -22,7 +22,7 @@ class FakeFontFace {
 describe('loadFontToDom', () => {
   let added: FakeFontFace[];
   let originalFontFace: unknown;
-  let originalFonts: unknown;
+  let originalFontsDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     added = [];
@@ -31,9 +31,15 @@ describe('loadFontToDom', () => {
       .FontFace;
     (globalThis as unknown as { FontFace: unknown }).FontFace = FakeFontFace;
 
-    originalFonts = document.fonts;
+    // Capture the whole descriptor, not just the value: jsdom has no
+    // `document.fonts` at all, so there may be nothing here to put back.
+    originalFontsDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      'fonts',
+    );
     Object.defineProperty(document, 'fonts', {
       configurable: true,
+      writable: true,
       value: { add: (f: FakeFontFace) => added.push(f) },
     });
   });
@@ -41,10 +47,17 @@ describe('loadFontToDom', () => {
   afterEach(() => {
     (globalThis as unknown as { FontFace: unknown }).FontFace =
       originalFontFace;
-    Object.defineProperty(document, 'fonts', {
-      configurable: true,
-      value: originalFonts,
-    });
+
+    // Restore exactly what was there — including nothing. Vitest runs with
+    // `isolate: false`, so this document is shared with every other test file,
+    // and tests/setup.ts assigns `document.fonts = {...}` when it finds it
+    // absent. Leaving a non-writable stand-in behind makes that assignment
+    // throw in whichever file happens to run next.
+    if (originalFontsDescriptor !== undefined) {
+      Object.defineProperty(document, 'fonts', originalFontsDescriptor);
+    } else {
+      delete (document as unknown as { fonts?: unknown }).fonts;
+    }
   });
 
   it('registers a single family name', () => {
@@ -91,5 +104,28 @@ describe('loadFontToDom', () => {
     // Give the rejection a turn to surface if it were unhandled.
     await new Promise((r) => setTimeout(r, 0));
     expect(added.map((f) => f.family)).toEqual(['Roboto']);
+  });
+});
+
+// Sibling block: runs outside the hooks above, so it sees the document exactly
+// as the next test file would. Guards the restore in `afterEach` — a leftover
+// non-writable `fonts` here makes tests/setup.ts throw
+// "Cannot assign to read only property 'fonts'" in an unrelated file.
+describe('loadFontToDom global cleanup', () => {
+  it('leaves document.fonts assignable for other test files', () => {
+    const before = Object.getOwnPropertyDescriptor(document, 'fonts');
+    expect(before === undefined || before.writable === true).toBe(true);
+
+    // The exact operation tests/setup.ts performs when it finds no fonts.
+    expect(() => {
+      (document as unknown as { fonts?: unknown }).fonts = { add: () => {} };
+    }).not.toThrow();
+
+    // ...and put it back, so this guard is itself side-effect free.
+    if (before !== undefined) {
+      Object.defineProperty(document, 'fonts', before);
+    } else {
+      delete (document as unknown as { fonts?: unknown }).fonts;
+    }
   });
 });

--- a/tests/loadFonts.test.ts
+++ b/tests/loadFonts.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+
+// `loadFonts()` may be called either side of `createRenderer()`. Calling it
+// first is the point of the prefetch: the download overlaps renderer boot
+// instead of queueing behind it. Calling it after must keep behaving exactly
+// as it always did.
+//
+// Both paths hinge on the module-level `renderer` in lightningInit being unset,
+// so each case re-imports the module against a mocked renderer package.
+
+const prefetchFont = vi.fn();
+const loadFont = vi.fn(() => Promise.resolve());
+
+vi.mock('@solidtv/renderer', () => {
+  class RendererMain {
+    root = {};
+    stage = {
+      renderer: { mode: 'webgl' },
+      textRenderers: { sdf: {} },
+      loadFont,
+    };
+    on() {}
+  }
+  return { RendererMain, prefetchFont };
+});
+
+const sdfFont = {
+  type: 'msdf' as const,
+  fontFamily: 'Roboto',
+  atlasUrl: 'Roboto.png',
+  atlasDataUrl: 'Roboto.json',
+};
+
+async function freshInit() {
+  vi.resetModules();
+  return import('../src/core/lightningInit.js');
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('loadFonts', () => {
+  beforeEach(() => {
+    prefetchFont.mockClear();
+    loadFont.mockClear();
+  });
+
+  // Leave the module registry clean for any test file that loads afterwards.
+  afterAll(() => {
+    vi.resetModules();
+  });
+
+  it('starts the download before the renderer exists, and attaches once it does', async () => {
+    const init = await freshInit();
+
+    const pending = init.loadFonts([sdfFont]);
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+
+    // Network started; nothing handed to a stage that does not exist yet.
+    expect(prefetchFont).toHaveBeenCalledWith(sdfFont);
+    expect(loadFont).not.toHaveBeenCalled();
+    await flush();
+    expect(settled).toBe(false);
+
+    init.startLightningRenderer({}, document.createElement('div'));
+
+    await pending;
+    expect(loadFont).toHaveBeenCalledWith('sdf', sdfFont);
+  });
+
+  it('attaches immediately when the renderer already exists', async () => {
+    const init = await freshInit();
+    init.startLightningRenderer({}, document.createElement('div'));
+
+    await init.loadFonts([sdfFont]);
+
+    expect(loadFont).toHaveBeenCalledWith('sdf', sdfFont);
+    // Nothing to prefetch — the stage is right there.
+    expect(prefetchFont).not.toHaveBeenCalled();
+  });
+
+  it('rejects the deferred call when attaching fails', async () => {
+    const init = await freshInit();
+    loadFont.mockImplementationOnce(() => Promise.reject(new Error('boom')));
+
+    const pending = init.loadFonts([sdfFont]);
+    init.startLightningRenderer({}, document.createElement('div'));
+
+    await expect(pending).rejects.toThrow('boom');
+  });
+
+  it('keeps working against a renderer with no prefetch support', async () => {
+    const renderer = await import('@solidtv/renderer');
+    const original = Reflect.get(renderer, 'prefetchFont') as unknown;
+    Reflect.set(renderer, 'prefetchFont', undefined);
+
+    try {
+      const init = await freshInit();
+      const pending = init.loadFonts([sdfFont]);
+      init.startLightningRenderer({}, document.createElement('div'));
+
+      await pending;
+      expect(loadFont).toHaveBeenCalledWith('sdf', sdfFont);
+    } finally {
+      Reflect.set(renderer, 'prefetchFont', original);
+    }
+  });
+});

--- a/tests/loadFonts.test.ts
+++ b/tests/loadFonts.test.ts
@@ -91,20 +91,18 @@ describe('loadFonts', () => {
     await expect(pending).rejects.toThrow('boom');
   });
 
-  it('keeps working against a renderer with no prefetch support', async () => {
-    const renderer = await import('@solidtv/renderer');
-    const original = Reflect.get(renderer, 'prefetchFont') as unknown;
-    Reflect.set(renderer, 'prefetchFont', undefined);
+  it('registers every alias of a multi-name font', async () => {
+    const init = await freshInit();
+    const aliased = { ...sdfFont, fontFamily: ['Roboto', 'Roboto500'] };
 
-    try {
-      const init = await freshInit();
-      const pending = init.loadFonts([sdfFont]);
-      init.startLightningRenderer({}, document.createElement('div'));
+    const pending = init.loadFonts([aliased]);
+    expect(prefetchFont).toHaveBeenCalledWith(aliased);
 
-      await pending;
-      expect(loadFont).toHaveBeenCalledWith('sdf', sdfFont);
-    } finally {
-      Reflect.set(renderer, 'prefetchFont', original);
-    }
+    init.startLightningRenderer({}, document.createElement('div'));
+    await pending;
+
+    // One descriptor, one load — the renderer registers every name from it.
+    expect(loadFont).toHaveBeenCalledTimes(1);
+    expect(loadFont).toHaveBeenCalledWith('sdf', aliased);
   });
 });


### PR DESCRIPTION
Requires `@solidtv/renderer` **>= 1.6.3**, which ships the stage-free `prefetchFont()` this builds on (landed in solid-tv/renderer#134). The peer dependency is bumped accordingly.

## Problem

`loadFonts()` read the module-level `renderer` set by `startLightningRenderer()`, so it could only be called *after* `createRenderer()`. Calling it earlier threw. That put every font download behind the renderer's synchronous boot — GL context, buffer allocation, shader compile — with the network idle the whole time.

## Change

`loadFonts()` is now order-independent:

- **Before `createRenderer()`** — starts the downloads immediately, queues the fonts, and `startLightningRenderer()` flushes the queue the moment a stage exists.
- **After `createRenderer()`** — takes the original code path, unchanged.

Opting in is one line moved up:

```js
loadFonts(fonts);
const { render, renderer } = createRenderer();
```

`render.ts` needed no change — the flush lives in `startLightningRenderer`, so it also covers any other caller.

## Backwards compatibility

The post-`createRenderer()` branch is the verbatim old function body (now `attachFonts`) — same branch order, same `stage.loadFont` calls, same `Promise<void>` return. An app that changes nothing behaves identically.

The peer dependency moves from `^1.5.4` to `^1.6.3`. Consumers pinned below that will need to update; there is no longer a fallback path, so a mismatched renderer fails at link time rather than silently skipping the prefetch.

The one behavioural change: an app that called `loadFonts()` before `createRenderer()` used to get a rejected promise (`Cannot read properties of undefined`) and now gets one that stays pending until the renderer is created. Only reachable from a boot path that was previously a guaranteed crash.

## Also fixes: aliased fonts on the DOM renderer

Renderer 1.6.x widened `FontLoadOptions['fontFamily']` to `string | string[]` for the multi-name alias support in solid-tv/renderer#133. `loadFontToDom` passed that value straight to `FontFace`, which stringifies an array into a single bogus family (`"Roboto,Roboto500"`) — so with the DOM renderer, **no** name in an alias list resolved. It now registers one face per name against the shared URL, which the browser dedupes into a single download. Caught by the type checker during the upgrade.

## Details worth a look

- **The DOM renderer path needs no stage at all**, so it completes inline rather than deferring.
- **Which half of a dual descriptor to warm** is decided from `Config.rendererOptions.fontEngines`, which is readable before the renderer exists. Attaching still uses the live `stage.renderer.mode` check, so a wrong guess costs one wasted request and never a failure.
- **`await loadFonts(fonts)` before `createRenderer()` will hang** — the promise resolves on *attach*, which needs a stage. Documented on the function. I kept resolve-on-attach rather than resolve-on-fetch so the promise keeps meaning "the fonts are usable".

## Verification

Driven in a browser against the **published 1.6.3**, using the built `dist` rather than source:

| event | t (ms) |
|---|---|
| `loadFonts()` called | 163 |
| `loadFonts()` returned | 164 |
| atlas `.json` + `.png` requested | 164 |
| atlas `.json` + `.png` complete | 168 |
| `createRenderer()` finished | 213 |
| fonts attached to the stage | 243 |

Both resources were fully downloaded 45 ms before the renderer finished constructing, each fetched exactly once, and text using an **alias** name rendered from the prefetched atlas.

- 148 tests pass (+7). Covers: deferred call attaches once the renderer exists; immediate attach when it already does; rejection propagates to the deferred caller; alias descriptors reach the renderer intact; and the DOM alias fan-out. The DOM alias test was confirmed to **fail** against the unfixed code.
- Typecheck, Prettier and ESLint clean; `npm run build` clean.

## Out of scope

The `mergeProps` work on `fix/proxy-free-merge-props` is unrelated and deliberately not included here.
