### PR TITLE
fix(mergeProps): handle function sources without Proxy support

### DIFF
--- a/src/mergeProps.ts
+++ b/src/mergeProps.ts
@@ -1,0 +1,48 @@
+import { mergeProps as solidMergeProps } from 'solid-js';
+
+/**
+ * Whether the host engine implements ES2015 `Proxy`. Chrome < 49 — notably the
+ * Chrome 38 engine on LG webOS 3.x and older Tizen — does not, which changes how
+ * solid-js merges props (see {@link mergeProps}).
+ */
+export const SUPPORTS_PROXY = typeof Proxy === 'function';
+
+/**
+ * Mirror of solid-js's internal `resolveSource`: a reactive spread source is
+ * handed to `mergeProps` as a thunk; calling it yields the object to merge.
+ */
+function resolveSource(source: unknown): unknown {
+  const value =
+    typeof source === 'function' ? (source as () => unknown)() : source;
+  return value == null ? {} : value;
+}
+
+/**
+ * Proxy-free-safe `mergeProps`, re-exported by the renderer so the JSX compiler
+ * (`moduleName: '@lightningtv/solid'`) routes every compiled spread through it.
+ *
+ * With `Proxy` this is solid-js's `mergeProps` unchanged. Without `Proxy`
+ * (Chrome 38 / webOS 3), solid-js falls back to a path that enumerates each
+ * source via `Object.getOwnPropertyNames`. A reactive spread — e.g.
+ * `<Comp {...someFn()} />`, which the compiler passes as a *function* — reaches
+ * that fallback as the function itself, so enumeration yields `['length','name']`
+ * (or throws on `caller`/`callee`/`arguments` for strict-mode functions) instead
+ * of the object's props, and every spread-provided prop is silently dropped.
+ *
+ * Resolving function sources to their objects first lets the fallback enumerate
+ * real props. Getters are preserved, so values stay reactive; only a source
+ * whose object *identity* changes over time won't re-track — an accepted limit
+ * of running without `Proxy`.
+ *
+ * @see https://github.com/solidjs/solid/issues/2282
+ */
+export const mergeProps = ((...sources: unknown[]) => {
+  if (SUPPORTS_PROXY) {
+    return solidMergeProps(...(sources as Parameters<typeof solidMergeProps>));
+  }
+  return solidMergeProps(
+    ...(sources.map((source) =>
+      typeof source === 'function' ? resolveSource(source) : source,
+    ) as Parameters<typeof solidMergeProps>),
+  );
+}) as typeof solidMergeProps;

--- a/src/render.ts
+++ b/src/render.ts
@@ -61,9 +61,13 @@ export const {
   insert,
   spread,
   setProp,
-  mergeProps,
   use,
 } = solidRenderer;
+
+// Re-export a Proxy-free-safe mergeProps in place of the renderer's own so the
+// JSX compiler routes compiled spreads through it — fixes dropped spread props
+// on engines without Proxy (Chrome 38 / webOS 3). See ./mergeProps.ts.
+export { mergeProps } from './mergeProps.js';
 
 type Task = () => void;
 const taskQueue: Task[] = [];

--- a/tests/mergeProps.test.ts
+++ b/tests/mergeProps.test.ts
@@ -1,0 +1,50 @@
+import * as v from 'vitest';
+
+// Reactive spreads (`<Comp {...fn()} />`) reach mergeProps as a function. On
+// engines without Proxy (Chrome 38 / webOS 3) solid-js's fallback enumerates
+// that function instead of the object it returns, dropping every spread prop.
+// The wrapper resolves function sources first. See src/mergeProps.ts.
+v.describe('mergeProps (Proxy-free safe)', () => {
+  v.afterEach(() => {
+    v.vi.unstubAllGlobals();
+    v.vi.resetModules();
+  });
+
+  v.test(
+    'delegates to solid-js mergeProps when Proxy is available',
+    async () => {
+      const { mergeProps, SUPPORTS_PROXY } =
+        await import('../src/mergeProps.js');
+      v.expect(SUPPORTS_PROXY).toBe(true);
+      const merged = mergeProps({ a: 1 }, { b: 2 }) as Record<string, unknown>;
+      v.expect(merged.a).toBe(1);
+      v.expect(merged.b).toBe(2);
+    },
+  );
+
+  v.test(
+    'preserves function-source (reactive spread) props without Proxy',
+    async () => {
+      v.vi.stubGlobal('Proxy', undefined);
+      v.vi.resetModules();
+      const { mergeProps, SUPPORTS_PROXY } =
+        await import('../src/mergeProps.js');
+      v.expect(SUPPORTS_PROXY).toBe(false);
+
+      const spread = () => ({
+        upCount: 4,
+        get buffer() {
+          return 5;
+        },
+      });
+      const merged = mergeProps(spread, { scroll: 'always' }) as Record<
+        string,
+        unknown
+      >;
+
+      v.expect(merged.scroll).toBe('always'); // direct prop survives
+      v.expect(merged.upCount).toBe(4); // spread prop (was dropped before)
+      v.expect(merged.buffer).toBe(5); // spread getter preserved
+    },
+  );
+});


### PR DESCRIPTION
## Summary

On engines without `Proxy` support (e.g. Chrome 38 on LG webOS 3.x), `solid-js`'s `mergeProps` fallback enumerates source objects via `Object.getOwnPropertyNames`. Reactive spreads (e.g. `<Comp {...fn()} />`) are passed into `mergeProps` as function thunks. Without `Proxy`, the fallback enumerates the function itself (yielding `['length', 'name']`) rather than calling it to resolve the target props object, causing spread props to be silently dropped.

This PR introduces a Proxy-free-safe `mergeProps` wrapper re-exported by the renderer (`src/render.ts`). When `Proxy` is unavailable, function sources are resolved to their underlying objects prior to delegation to `solid-js`'s `mergeProps`, ensuring spread properties and getters are properly preserved on legacy web engines.

## Changes
- **`src/mergeProps.ts`**: Implementation of `mergeProps` wrapper with engine `Proxy` detection.
- **`src/render.ts`**: Re-export wrapper in place of standard renderer export so JSX compiled spreads route through it.
- **`tests/mergeProps.test.ts`**: Unit tests verifying behavior both with `Proxy` present and mocked as undefined.