### PR TITLE
fix(spatialHandleNavigation): don't reset selection at grid edges

### DIFF
--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -377,6 +377,10 @@ export const spatialHandleNavigation: lng.KeyHandler = function (e) {
       closestIdx = i;
     }
 
+    // No child in an adjacent column/row - keep the current selection so the
+    // next key press resumes from here instead of resetting to the first child.
+    if (closestIdx === -1) return false;
+
     return selectChild(this as lngp.NavigableElement, closestIdx);
   }
 

--- a/tests/spatialNavigation.test.tsx
+++ b/tests/spatialNavigation.test.tsx
@@ -1,0 +1,112 @@
+import * as v from 'vitest';
+import * as lng from '@solidtv/solid';
+import {
+  useFocusManager,
+  spatialForwardFocus,
+  spatialHandleNavigation,
+} from '@solidtv/solid/primitives';
+import { renderer, waitForUpdate } from './setup.js';
+
+const key = (k: string) =>
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: k }));
+
+// 3x2 wrapped grid:
+//   0 1 2
+//   3 4
+let grid!: lng.ElementNode;
+
+v.beforeAll(async () => {
+  renderer.render(() => {
+    useFocusManager();
+    return (
+      <view
+        ref={grid}
+        autofocus
+        display="flex"
+        flexWrap="wrap"
+        width={300}
+        height={200}
+        selected={0}
+        forwardFocus={spatialForwardFocus}
+        onUp={spatialHandleNavigation}
+        onDown={spatialHandleNavigation}
+        onLeft={spatialHandleNavigation}
+        onRight={spatialHandleNavigation}
+      >
+        {Array.from({ length: 5 }, () => (
+          <view width={100} height={100} />
+        ))}
+      </view>
+    );
+  });
+  await waitForUpdate();
+});
+
+// Each test starts from an explicit child so it doesn't inherit the previous
+// test's selection.
+function focusChild(index: number) {
+  grid.selected = index;
+  (grid.children[index] as lng.ElementNode).setFocus();
+}
+
+v.describe('spatialHandleNavigation', () => {
+  v.test('lays out the fixture as a wrapped 3x2 grid', () => {
+    v.assert.deepEqual(
+      grid.children.map((c) => [
+        (c as lng.ElementNode).x,
+        (c as lng.ElementNode).y,
+      ]),
+      [
+        [0, 0],
+        [100, 0],
+        [200, 0],
+        [0, 100],
+        [100, 100],
+      ],
+    );
+  });
+
+  v.test('keeps the selection when there is no row below', () => {
+    focusChild(0);
+
+    key('ArrowDown'); // 0 -> 3
+    v.assert.equal(grid.selected, 3);
+
+    key('ArrowDown'); // no row below - selection must stay put
+    v.assert.equal(grid.selected, 3);
+
+    key('ArrowDown'); // still 3, not reset to the first child
+    v.assert.equal(grid.selected, 3);
+
+    key('ArrowUp'); // back up to 0
+    v.assert.equal(grid.selected, 0);
+  });
+
+  v.test('keeps the selection when there is no row above', () => {
+    focusChild(1);
+
+    key('ArrowUp'); // no row above - selection must stay put
+    v.assert.equal(grid.selected, 1);
+
+    key('ArrowUp'); // still 1, not reset to the first child
+    v.assert.equal(grid.selected, 1);
+
+    key('ArrowDown'); // 1 -> 4
+    v.assert.equal(grid.selected, 4);
+  });
+
+  v.test('keeps the selection at the row edges', () => {
+    focusChild(0);
+
+    key('ArrowLeft'); // already leftmost
+    v.assert.equal(grid.selected, 0);
+
+    focusChild(2);
+
+    key('ArrowRight'); // end of the row, must not wrap or reset
+    v.assert.equal(grid.selected, 2);
+
+    key('ArrowLeft'); // 2 -> 1
+    v.assert.equal(grid.selected, 1);
+  });
+});


### PR DESCRIPTION
## What

`spatialHandleNavigation` reset the container's `selected` to `-1` whenever a cross-axis move failed at an edge, which made the *next* key press jump focus back to the first child.

## Why

In the cross-axis branch (up/down in a row-wrapped container, left/right in a column-wrapped one), the handler called `selectChild(el, closestIdx)` unconditionally — including when the scan found nothing and left `closestIdx === -1`. `selectChild` treats an invalid index as "clear the selection":

```ts
if (child == null || child.skipFocus) {
  el.selected = -1;
  return false;
}
```

So a no-op edge move silently wiped `selected`. On the next press, the guard at the top of the handler saw `selected === -1`, treated it as "nothing selected", and fell back to `findFirstFocusableChildIdx` → the first child.

Reported symptoms, both reproduced: holding **Down** on the bottom row bounces focus to the first item, and holding **Up** from a first-row item does the same.

The in-flex-direction branch already returned `false` without touching `selected`, which is why only cross-axis moves were affected.

## The change

Return `false` when no adjacent row/column exists, before `selectChild` can clobber the selection:

```ts
// No child in an adjacent column/row - keep the current selection so the
// next key press resumes from here instead of resetting to the first child.
if (closestIdx === -1) return false;
```

Returning `false` also lets the key bubble to a parent container, which is the desired behavior at a boundary.

## Notes for reviewers

I deliberately kept the guard local to `spatialHandleNavigation` rather than removing the `el.selected = -1` reset inside `selectChild`. That reset is still correct for `navigableForwardFocus` and `spatialForwardFocus`, which call it for the genuinely-no-focusable-children case.

## Tests

New `tests/spatialNavigation.test.tsx` builds a 3×2 wrapped flex grid (`0 1 2 / 3 4`) and drives it through the real focus manager with dispatched `keydown` events — it asserts the flex layout first, then that repeated Down on the bottom row and repeated Up on the top row hold their selection and still navigate correctly afterward.

- Confirmed the new tests fail on `main` (`expected -1 to equal 3`, `expected -1 to equal 1`) and pass with the fix.
- Full suite: 174 passed / 17 files.
- `npm run tsc` clean; `npm run lint` 0 errors (pre-existing warnings unchanged).

One fixture note if these tests get extended: `spatialForwardFocus` selects the child closest to the previously active element, so rendering a fresh grid per test inherits the prior grid's position. The suite renders once in `beforeAll` and sets focus explicitly per case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)